### PR TITLE
Improve automatic browser based language selection

### DIFF
--- a/MaterialSkin/HTML/material/html/js/constants.js
+++ b/MaterialSkin/HTML/material/html/js/constants.js
@@ -13,3 +13,11 @@ const LMS_STATUS_REFRESH_MIN = 1000;
 const LMS_STATUS_REFRESH_MAX = 3000;
 
 const LMS_DEFAULT_LIBRARY = "0";
+
+const SKIN_LANGUAGES = {
+	de: true,
+	en: true,
+	'en-gb': true,
+	fr: true,
+	nl: true
+};

--- a/MaterialSkin/HTML/material/html/js/main.js
+++ b/MaterialSkin/HTML/material/html/js/main.js
@@ -262,6 +262,9 @@ var app = new Vue({
                     }
                 }
                 if (lang != 'en') {
+                    if (!SKIN_LANGUAGES[lang])
+                        lang = lang.substr(0, 2);
+                    
                     axios.get("html/lang/"+lang+".json").then(function (resp) {
                         var trans = eval(resp.data);
                         setLocalStorageVal('translation', JSON.stringify(trans));


### PR DESCRIPTION
Check whether the browser's language is available for the skin. If it's not, shorten to the two first characters and try again. This should cover falling back from de_CH to de etc.