### PR TITLE
Add cache-buster in page handler.

### DIFF
--- a/MaterialSkin/HTML/material/desktop.html
+++ b/MaterialSkin/HTML/material/desktop.html
@@ -13,7 +13,7 @@
     <title>Logitech Media Server</title>
     <link href="html/css/blank.css" rel="stylesheet">
     <link href="html/css/blank.css" rel="stylesheet">
-    <link href="html/font/font.css" rel="stylesheet">
+    <link href="html/font/font.css?r=[% material_revision %]" rel="stylesheet">
     <link href="html/lib/vuetify.min.css?ver=1.3.5" rel="stylesheet">
     <!-- TODO: Fix and re-use virtual scroller -->
     <!-- <link href="html/lib/vue-virtual-scroller.css?ver=0.12.2" rel="stylesheet"> -->

--- a/MaterialSkin/Plugin.pm
+++ b/MaterialSkin/Plugin.pm
@@ -1,11 +1,20 @@
 package Plugins::MaterialSkin::Plugin;
 
 sub initPlugin {
+    my $class = shift;
+
     if (main::WEBUI) {
         Slim::Web::Pages->addPageFunction( 'desktop', sub {
-            return Slim::Web::HTTP::filltemplatefile('desktop.html', $_[1]);
+            my ($client, $params) = @_;
+            $params->{'material_revision'} = $class->pluginVersion();
+            return Slim::Web::HTTP::filltemplatefile('desktop.html', $params);
         } );
     }
+}
+
+sub pluginVersion {
+    my ($class) = @_;
+    return Slim::Utils::PluginManager->dataForPlugin($class)->{version};
 }
 
 1;


### PR DESCRIPTION
By using the plugin version rather than the individual library versions you wouldn't have to maintain those references. This wouldn't save all the pain for your, but for most users it should work just fine. The cached copies would be refreshed whenever you release a new version.

You could then add a similar handler for the mobile version.

**Please note** that this change **is not complete** at all. You'd have to replace all library specific numbers with the template snippet, plus add it to all of your own JS file references. But I guess you get the idea.

The Perl part would get your plugin's version number and pass it to the page renderer as a new variable `material_revision`. The `[% material_revision %]` then does put that string in place in the page template. (we're using the Perl [Template Toolkit](http://www.template-toolkit.org/docs/manual/Directives.html#section_GET) if you're interested in the details about the syntax)