### PR TITLE
Add support for virtual and remote library menus

### DIFF
--- a/MaterialSkin/HTML/material/html/js/browse-page.js
+++ b/MaterialSkin/HTML/material/html/js/browse-page.js
@@ -1199,6 +1199,18 @@ var lmsBrowse = Vue.component("lms-browse", {
                                                       icon: "shuffle",
                                                       id: TOP_RANDOM_MIX_ID,
                                                       weight: c.weight ? parseFloat(c.weight) : 100 });
+                            } else if (c.id == "opmlselectVirtualLibrary" || c.id == "opmlselectRemoteLibrary") {
+                                var command = this.buildCommand(c, "go", false, true);
+                                this.serverTop.push({
+                                    title: c.text,
+                                    command: command.command,
+                                    params: command.params,
+                                    weight: c.weight ? parseFloat(c.weight) : 100,
+                                    icon: "library_music",
+                                    id: TOP_ID_PREFIX + c.id
+                                });
+                            } else {
+                                console.log(`Unsupported menu? ${c.id}`);
                             }
                         }
                     });

--- a/MaterialSkin/HTML/material/html/js/server.js
+++ b/MaterialSkin/HTML/material/html/js/server.js
@@ -23,7 +23,7 @@ function lmsCommand(playerid, command) {
 
 function lmsList(playerid, command, params, start, batchSize) {
     var cmdParams = command.slice();
-    cmdParams = [].concat(cmdParams, [start, undefined===batchSize ? LMS_BATCH_SIZE : batchSize]);
+    cmdParams = [].concat(cmdParams, [start || 0, undefined===batchSize ? LMS_BATCH_SIZE : batchSize]);
     if (params && params.length>0) {
         cmdParams = [].concat(cmdParams, params);
     }


### PR DESCRIPTION
The menu items to select a library view or browse remote sources (if that plugin is enabled) are missing.

That said: library support seems to be broken currently. Somehow the `library_id` is never sent to the server. I'd always get the full library.