### PR TITLE
Do NOT hide player controls when a player is powered off.

### DIFF
--- a/MaterialSkin/HTML/material/html/js/nowplaying-page.js
+++ b/MaterialSkin/HTML/material/html/js/nowplaying-page.js
@@ -92,7 +92,7 @@ var lmsNowPlaying = Vue.component("lms-now-playing", {
   </v-card>
  </div>
 </div>
-<div class="np-page bgnd-cover" v-else-if="playerStatus.ison" id="np-page">
+<div class="np-page bgnd-cover" v-else id="np-page">
  <div v-if="info.show" class="np-info bgnd-cover" id="np-info">
   <v-tabs centered v-model="info.tab" class="np-info-tab-cover">
    <template v-for="(tab, index) in info.tabs">


### PR DESCRIPTION
I know that you expressed your intention not to add this. But really: in mobile mode it now takes at least three taps to start playback on a powered off Radio. With the controls there, it's one. The minimum there can be. Please :-).

![2018-12-22 14 43 59](https://user-images.githubusercontent.com/2789989/50375811-a8501580-0603-11e9-9de2-647df8cc735f.png)

I'd have to 
* tap player selector
* select player 
* tap player selector again
* power on
* start playback
