### PR TITLE
Display the git revision when running from a git clone

### DIFF
--- a/MaterialSkin/Plugin.pm
+++ b/MaterialSkin/Plugin.pm
@@ -20,11 +20,23 @@ sub initPlugin {
 sub pluginVersion {
     my ($class) = @_;
     my $version = Slim::Utils::PluginManager->dataForPlugin($class)->{version};
+    
+    if ($version eq 'DEVELOPMENT') {
+        # Try to get the git revision from which we're running
+        if (my ($skinDir) = grep /MaterialSkin/, @{Slim::Web::HTTP::getSkinManager()->_getSkinDirs() || []}) {
+            my $revision = `cd $skinDir && git show -s --format=%h\\|%ci 2> /dev/null`;
+            if ($revision =~ /^([0-9a-f]+)\|(\d{4}-\d\d-\d\d.*)/i) {
+                $version = 'GIT-' . $1;
+            }
+        }
+    }
+
     if ($version eq 'DEVELOPMENT') {
         use POSIX qw(strftime);
         $datestring = strftime("%Y-%m-%d-%H-%M-%S", gmtime);
         $version = "${version}-${datestring}";
     }
+
     return $version;
 }
 


### PR DESCRIPTION
Giving a time stamp is pretty useless, as it would always be the time when the page was loaded, without any reference to what we're actually running.

My proposed implementation admittedly is reaching out deep into LMS code... but it should allow us to reliably figure out where the plugin is being installed, as it can be in quite a few different places. It does get the list of folders being used by LMS' templating engine, and picks the one matching the MaterialSkin name. That folder can be expected to be in the git clone, where we can get the revision.