### PR TITLE
Add skin configuration files to make Material selectable as the skin,…

### DIFF
--- a/MaterialSkin/HTML/material/cmdwrappers_Material
+++ b/MaterialSkin/HTML/material/cmdwrappers_Material
@@ -1,0 +1,1 @@
+[% PROCESS cmdwrappers_Default %]

--- a/MaterialSkin/HTML/material/skinconfig.yml
+++ b/MaterialSkin/HTML/material/skinconfig.yml
@@ -1,0 +1,5 @@
+---
+preprocess:
+ - cmdwrappers_Material
+skinparents:
+ - Default


### PR DESCRIPTION
… but still use the Default's settings pages.

Don't know if you're interested in this. But this would allow you to select Material as your skin, and still be able to access settings from `/settings` rather than `/Default/settings`. It's a minor change to solve a minor problem :-).

Only caveat: you must not use any path/file name which might override one of Default's. But so far you look good.