### PR TITLE
Make sure the scanner does pre-cache album artwork in the size used i…

### DIFF
--- a/MaterialSkin/Plugin.pm
+++ b/MaterialSkin/Plugin.pm
@@ -43,6 +43,9 @@ sub initPlugin {
             return Slim::Web::HTTP::filltemplatefile('mobile.html', $params);
         } );
         Slim::Web::Pages->addRawFunction($URL_PARSER_RE, \&_svgHandler);
+
+        # make sure scanner does pre-cache artwork in the size the skin is using in browse modesl
+        Slim::Control::Request::executeRequest(undef, [ 'artworkspec', 'add', '300x300_f', 'Material Skin' ]);
     }
 
     $class->initCLI();


### PR DESCRIPTION
…n browse modes

Without pre-caching LMS would resize images on the fly. This can considerably slow down browsing the library. By pre-caching those files LMS can quickly read the re-sized artwork from its cache.

Make sure the spec matches the LMS_GRID_IMAGE_SIZE in constants.js. 

iPeng users might already have this size registered. But it doesn't hurt to configure it for the other users, too. See Settings/Advanced/Performance.