### PR TITLE
Fix #171 - Use light/dark skin in settings depending on Material pref

### DIFF
--- a/MaterialSkin/HTML/material/html/css/classic-skin-mods-light.css
+++ b/MaterialSkin/HTML/material/html/css/classic-skin-mods-light.css
@@ -72,8 +72,8 @@ select:-webkit-autofill:focus {
 
 input[type="submit"], input[type="button"] {
  color: black !important;
- background-color: #ccc;
- border-bottom: 1px solid #aaa;
+ background-color: transparent;
+ border: 1px solid #aaa;
 }
 
 input[type="submit"]:hover, input[type="button"]:hover {

--- a/MaterialSkin/HTML/material/html/css/classic-skin-mods.css
+++ b/MaterialSkin/HTML/material/html/css/classic-skin-mods.css
@@ -65,7 +65,7 @@ div#browsedbList {
  margin-bottom:8px;
  font-size:16px !important;
  font-weight:400 !important;
- border-radius: 0px;
+ border-radius: 3px;
 }
 
 #statusMessage {
@@ -148,13 +148,18 @@ select, input {
  cursor: pointer;
 }
 
+input[type="text"], input[type="button"], input[type="submit"] {
+ -webkit-appearance: none;
+ appearance: none;
+}
+
 select {
  border: none;
  text-overflow:ellipsis;
  overflow:hidden;
  white-space:nowrap;
  max-width:calc(100vw - 32px);
- border-radius: 0px;
+ border-radius: 3px;
  min-height:26px;
  margin-bottom:1px;
 }

--- a/MaterialSkin/HTML/material/html/js/information.js
+++ b/MaterialSkin/HTML/material/html/js/information.js
@@ -303,7 +303,7 @@ Vue.component('lms-information-dialog', {
             }
         },
         openSettings() {
-            bus.$emit('dlg.open', 'iframe', '/material/settings/server/basic.html', i18n('Server settings'));
+            bus.$emit('dlg.open', 'iframe', '/material/settings/server/basic.html?darkUi=' + (this.$store.state.darkUi ? 1 : 0), i18n('Server settings'));
         }
     },
     beforeDestroy() {

--- a/MaterialSkin/HTML/material/skin.css
+++ b/MaterialSkin/HTML/material/skin.css
@@ -1,4 +1,2 @@
-@import url("/Classic/slimserver.css");
 @import url("/material/html/font/font.css");
 @import url("/material/html/css/classic-skin-mods.css");
-@import url("/material/html/css/classic-skin-mods-dark.css");

--- a/MaterialSkin/HTML/material/standardheader.html
+++ b/MaterialSkin/HTML/material/standardheader.html
@@ -1,0 +1,12 @@
+<title>[% IF pagetitle %][% pagetitle | html -%][% ELSE %][% "SQUEEZEBOX_SERVER" | string %][% END -%]asdf[% skinVersion %]</title>
+<link rel="shortcut icon" href="[% webroot %]favicon.ico" type="image/x-icon"/>
+<link rel="icon" href="[% webroot %]favicon.ico" type="image/x-icon"/>
+<meta http-equiv="Content-Type" content="text/html; charset=[% LOCALE %]"/>
+<link rel="stylesheet" type="text/css" href="[% webroot %]slimserver.css?r=[% revision %]"/>
+<link rel="stylesheet" type="text/css" href="[% webroot %]skin.css?r=[% revision %]" />
+<link rel="stylesheet" type="text/css" href="[% webroot %]html/css/classic-skin-mods-[% IF darkUi; "dark"; ELSE; "light"; END %].css?r=[% revision %]"/>
+<link rel="apple-touch-icon" href="[% webroot %]html/images/apple-touch-icon.png"/>
+[% IF mobileBrowser %]
+	<meta name="viewport" content="width=device-width">
+	<link rel="stylesheet" type="text/css" href="[% webroot %]mobile.css"/>
+[% END %]


### PR DESCRIPTION
* add parameter "darkUi" to calling the settings
* add standardheader.html template override to handle the skin selection
* rename slimserver.css to skin.css, no need to Classic's slimserver.css
* tweak some styles for iOS devices
  - need to reset button appearance in order to style them
  - give selects a 3px radius