### PR TITLE
Hide checkbox and radio for good - iOS needs some special care?

### DIFF
--- a/MaterialSkin/HTML/material/html/css/classic-skin-mods-light.css
+++ b/MaterialSkin/HTML/material/html/css/classic-skin-mods-light.css
@@ -85,6 +85,10 @@ input[type="submit"]:active, input[type="button"]:active {
  border-bottom: 1px solid white;
 }
 
+input[type=checkbox] {
+ border: none;
+}
+
 input[type=checkbox]:checked:before, input[type=radio]:checked:before {
  color:#316dd3;
 }

--- a/MaterialSkin/HTML/material/html/css/classic-skin-mods.css
+++ b/MaterialSkin/HTML/material/html/css/classic-skin-mods.css
@@ -205,6 +205,11 @@ input[type=checkbox]:checked:before {
  content:"\e834";
 }
 
+input[type=radio] {
+ border:none;
+ background-color: transparent;
+}
+
 input[type=radio]:before {
  vertical-align: sub;
  font-family: "Material Icons";


### PR DESCRIPTION
I didn't see this in any of the desktop browsers. But on the iPhone there would be the original checkbox in the background of the styled one.