### PR TITLE
Expand names and descriptions in web app manifests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.webmanifest]
+indent_style = space
+indent_size = 2

--- a/MaterialSkin/HTML/material/html/desktop.webmanifest
+++ b/MaterialSkin/HTML/material/html/desktop.webmanifest
@@ -1,6 +1,7 @@
 {
-  "name": "LMS Desktop UI",
+  "name": "Logitech Media Server Material for desktop",
   "short_name": "LMS",
+  "description": "A Material-style interface for controlling Squeezebox-compatible network music playing devices.",
   "theme_color": "#424242",
   "background_color": "#424242",
   "display": "standalone",
@@ -12,6 +13,9 @@
       "sizes": "144x144",
       "type": "image/png"
     }
+  ],
+  "categories": [
+    "music"
   ],
   "splash_pages": null
 }

--- a/MaterialSkin/HTML/material/html/mobile.webmanifest
+++ b/MaterialSkin/HTML/material/html/mobile.webmanifest
@@ -1,6 +1,7 @@
 {
-  "name": "LMS Mobile UI",
+  "name": "Logitech Media Server Material for mobile",
   "short_name": "LMS",
+  "description": "A mobile-friendly Material-style interface for controlling Squeezebox-compatible network music playing devices.",
   "theme_color": "#424242",
   "background_color": "#424242",
   "display": "fullscreen",
@@ -12,6 +13,9 @@
       "sizes": "144x144",
       "type": "image/png"
     }
+  ],
+  "categories": [
+    "music"
   ],
   "splash_pages": null
 }

--- a/MaterialSkin/HTML/material/html/nowplaying.webmanifest
+++ b/MaterialSkin/HTML/material/html/nowplaying.webmanifest
@@ -1,6 +1,7 @@
 {
-  "name": "LMS Now-Playing",
+  "name": "Logitech Media Server Material now-playing",
   "short_name": "LMS",
+  "description": "A dashboard showing what’s currently playing on your Squeezebox-compatible network music playing devices.",
   "theme_color": "#424242",
   "background_color": "#424242",
   "display": "fullscreen",
@@ -12,6 +13,9 @@
       "sizes": "144x144",
       "type": "image/png"
     }
+  ],
+  "categories": [
+    "music"
   ],
   "splash_pages": null
 }


### PR DESCRIPTION
I find three letter acronyms unfriendly.  There's not enough space in the `short_name` field to spell the name out in full, but there is in the `name` field.  I realise this is subjective, so won't be offended if this is rejected.

While here I've added a category and a description.

I've also added a `.editorconfig` file which will cause compatible editors to indent .webmanifest files by 2 columns.