### PR TITLE
Enable a limited set of the Interface Settings

### DIFF
--- a/MaterialSkin/HTML/material/html/js/iframe-dialog.js
+++ b/MaterialSkin/HTML/material/html/js/iframe-dialog.js
@@ -72,8 +72,6 @@ function hideClassicSkinElems(page, showAll) {
         if (!showAll) {
             if ('player'==page) {
                 toHide = new Set(['ALARM', 'PLUGIN_DSTM']);
-            } else if ('server'==page) {
-                toHide = new Set(['INTERFACE_SETTINGS']);
             }
         }
         if ('search'==page) {

--- a/MaterialSkin/HTML/material/settings/server/interface.html
+++ b/MaterialSkin/HTML/material/settings/server/interface.html
@@ -1,0 +1,70 @@
+[% PROCESS settings/header.html %]
+
+	[% WRAPPER setting title="SETUP_SKIN" desc="SETUP_SKIN_DESC" %]
+		<select class="stdedit" name="pref_skin" id="skin">
+
+		[% FOREACH option = skinoptions.keys %]
+
+			<option [% IF prefs.pref_skin == option %]selected [% END %]value="[% option %]">[% skinoptions.$option %]</option>
+
+		[%- END -%]
+
+		</select>
+	[% END %]
+
+	<input type="hidden" name="pref_showArtist" value="[% prefs.pref_showArtist %]">
+	<input type="hidden" name="pref_showYear" value="[% prefs.pref_showYear %]">
+
+	<input type="hidden" name="pref_titleFormatWeb" value="[% prefs.pref_titleFormatWeb %]">
+	[% FOREACH format = prefs.pref_titleFormat %]
+		<input type="hidden" name="pref_titleFormat[% loop.index %]" value="[% format %]">
+	[% END %]
+
+	<input type="hidden" name="pref_itemsPerPage" value="[% prefs.pref_itemsPerPage %]">
+	<input type="hidden" name="pref_refreshRate" value="[% prefs.pref_refreshRate %]">
+	<input type="hidden" name="pref_thumbSize" value="[% prefs.pref_thumbSize %]">
+
+	[% WRAPPER settingSection %]
+		[% WRAPPER settingGroup title="SETUP_LONGDATEFORMAT" desc="SETUP_LONGDATEFORMAT_DESC" %]
+			<select class="stdedit" name="pref_longdateFormat" id="longdateFormat">
+
+			[% FOREACH option = longdateoptions.keys %]
+
+				<option [% IF prefs.pref_longdateFormat == option %]selected [% END %]value="[% option %]">[% longdateoptions.$option %]</option>
+
+			[%- END -%]
+
+			</select>
+		[% END %]
+
+		[% WRAPPER settingGroup title="SETUP_SHORTDATEFORMAT" desc="SETUP_SHORTDATEFORMAT_DESC" %]
+			<select class="stdedit" name="pref_shortdateFormat" id="shortdateFormat">
+
+			[% FOREACH option = shortdateoptions.keys %]
+
+				<option [% IF prefs.pref_shortdateFormat == option %]selected [% END %]value="[% option %]">[% shortdateoptions.$option %]</option>
+
+			[%- END -%]
+
+			</select>
+		[% END %]
+
+		[% WRAPPER settingGroup title="SETUP_TIMEFORMAT" desc="SETUP_TIMEFORMAT_DESC" %]
+			<select class="stdedit" name="pref_timeFormat" id="timeFormat">
+
+			[% FOREACH option = timeoptions.keys %]
+
+				<option [% IF prefs.pref_timeFormat == option %]selected [% END %]value="[% option %]">[% timeoptions.$option %]</option>
+
+			[%- END -%]
+
+			</select>
+		[% END %]
+	[% END %]
+
+	[% WRAPPER setting title="SETUP_DISPLAYTEXTTIMEOUT" desc="SETUP_DISPLAYTEXTTIMEOUT_DESC"%]
+		<input type=text class="stdedit sliderInput_1_100" name="pref_displaytexttimeout" id="displaytexttimeout" value="[% prefs.pref_displaytexttimeout || 0 %]" size="15">
+	[% END %]
+
+[% PROCESS settings/footer.html %]
+


### PR DESCRIPTION
Disabling this page has lead to some irritation - and cranky reactions. I believe that it should not be removed all together, as it covers some preferences which are not only crucial to the default web UI, but are settings to be used on the old players, too (Boom, Classic etc.).

I believe removing the skin selector alone has led to more confusion than leaving the full page there would ever have caused. I'd therefore suggest you include a limited set of options to ease the pain both for your users, as well as yourself. This patch does hide the options I believe you consider confusing, but still gives users access to UI settings they might need, like available formatting options in the classic player UI, the skin selector etc. This choice obviously could be tweaked if desired.

What I'm doing here is copy the original template and replace the input fields with hidden fields and put it in your skin folder. This form hasn't changed in years. This should be pretty safe.