### PR TITLE
Tolerate non-string firmware values

### DIFF
--- a/MaterialSkin/HTML/material/html/js/icon-mapping.js
+++ b/MaterialSkin/HTML/material/html/js/icon-mapping.js
@@ -53,7 +53,7 @@ function mapPlayerIcon(player) {
             }
             if (undefined!=player.firmware && undefined!=model['firmware']) {
                 for (let i=0, len=model['firmware'].length; i<len; ++i) {
-                    if (model['firmware'][i]['ends'] && player.firmware.endsWith(model['firmware'][i]['ends'])) {
+                    if (model['firmware'][i]['ends'] && ('' + player.firmware).endsWith(model['firmware'][i]['ends'])) {
                         return model['firmware'][i];
                     }
                 }


### PR DESCRIPTION
Player drop-down creation was failing because some of my players have firmware values that are numbers and not strings.