### PR TITLE
Detect Raspberry Pi from MAC address

### DIFF
--- a/MaterialSkin/HTML/material/html/js/icon-mapping.js
+++ b/MaterialSkin/HTML/material/html/js/icon-mapping.js
@@ -83,6 +83,13 @@ function mapPlayerIcon(player) {
                     }
                 }
             }
+            if (undefined!=player.playerid && undefined!=model['playerid']) {
+                for (let i=0, len=model['playerid'].length; i<len; ++i) {
+                    if (model['playerid'][i]['begins'] && ('' + player.playerid).startsWith(model['playerid'][i]['begins'])) {
+                        return model['playerid'][i];
+                    }
+                }
+            }
         }
     }
 

--- a/MaterialSkin/HTML/material/html/misc/player-icons.json
+++ b/MaterialSkin/HTML/material/html/misc/player-icons.json
@@ -33,6 +33,16 @@
                 "svg":"raspberry-pi"
             }
         ],
+        "playerid":[
+            {
+                "begins":"b8:27:eb:",
+                "svg":"raspberry-pi"
+            },
+            {
+                "begins":"dc:a6:32:",
+                "svg":"raspberry-pi"
+            }
+        ],
         "RaopBridge":{
             "svg":"airplay"
         },


### PR DESCRIPTION
This works regardless of what SqueezeLite reports as its firmware version.

MAC address blocks as listed at http://standards-oui.ieee.org/oui.txt