### PR TITLE
Fix URL query handling of urlencoded player names

### DIFF
--- a/MaterialSkin/HTML/material/html/js/utils.js
+++ b/MaterialSkin/HTML/material/html/js/utils.js
@@ -44,7 +44,7 @@ function parseQueryParams() {
     for (var i = query.length - 1; i >= 0; i--) {
         var kv = query[i].split('=');
         if ("player"==kv[0]) {
-            setLocalStorageVal("player", kv[1]);
+            setLocalStorageVal("player", decodeURIComponent(kv[1]));
             removeLocalStorage("defaultPlayer");
             resp.player=kv[1];
         } else if ("page"==kv[0]) {


### PR DESCRIPTION
Player names are passed in as urlencoded strings (.../material/?player=Player%20Name) but weren't being decoded.  This patch adds a call to decodeURIComponent when fetching the parameter.