### PR TITLE
Links in preference descriptions are larger than the description itself

### DIFF
--- a/MaterialSkin/HTML/material/html/css/classic-skin/mods.css
+++ b/MaterialSkin/HTML/material/html/css/classic-skin/mods.css
@@ -141,7 +141,7 @@ td input[type=checkbox] { /* Fix checkbox in Performance / Custom pre-caching sp
  vertical-align: text-bottom !important;
 }
 
-div.prefDesc, p {
+div.prefDesc, div.prefDesc a, p {
  font-size:14px!important;
 }
 


### PR DESCRIPTION
A really minor change to fix link's font size.