### PR TITLE
Added BBC Sounds to the list of acceptable global search sources

### DIFF
--- a/MaterialSkin/HTML/material/html/js/search-field.js
+++ b/MaterialSkin/HTML/material/html/js/search-field.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-const SEARCH_OTHER = new Set(['Deezer', 'Qobuz', 'Spotty', 'Tidal', 'YouTube']);
+const SEARCH_OTHER = new Set(['BBC Sounds', 'Deezer', 'Qobuz', 'Spotty', 'Tidal', 'YouTube']);
 
 let seachReqId = 0;
 Vue.component('lms-search-field', {


### PR DESCRIPTION
Hi
Would you please consider adding BBC Sounds to the list of acceptable global search sources.
I guess there is a reason that you have put the hard coded limitation in. So no worries if you don't want to.

I've tested the change and all works fine : 
![image](https://user-images.githubusercontent.com/73394021/100540833-c71ba580-3237-11eb-9023-f825bfcbd170.png)

![image](https://user-images.githubusercontent.com/73394021/100540856-e31f4700-3237-11eb-964b-95272cfd5ab1.png)
