### PR TITLE
Use LMS' own advanced search params parser (if available - requires 8.2+)

### DIFF
--- a/MaterialSkin/Search.pm
+++ b/MaterialSkin/Search.pm
@@ -25,7 +25,7 @@ use Slim::Utils::Log;
 use Slim::Utils::Prefs;
 
 sub advancedSearch {
-	my $params  = shift;
+	my ($client, $params) = @_;
 
 	my %query   = ();
 	my @qstring = ();


### PR DESCRIPTION
If LMS supports the `Slim::Web::Pages::Search::parseAdvancedSearchParams()` function, use it instead of the plugin's copy of that code.

In order to achieve this I've added a stub inline module `Plugins::MaterialSkin::Search`. If LMS doesn't support the aforementioned call, the plugin is requiring the `Search.pm` module, which would override the stub with its own implementation.

New LMS builds supporting this feature should be out soon, the change already is committed to https://github.com/Logitech/slimserver/commit/d776dc6292195e6511cb14c741bd39049b872614.