### PR TITLE
Adjust album grid paddings

### DIFF
--- a/MaterialSkin/HTML/material/html/css/style.css
+++ b/MaterialSkin/HTML/material/html/css/style.css
@@ -350,13 +350,13 @@ div.v-subheader {
 .lms-image-grid {
  overflow-x:hidden !important;
  overflow-y:auto !important;
- padding: 8px 4px 8px 0px;/* t, r, b, l */
+ padding: 8px 4px 8px 4px;/* t, r, b, l */
 }
 
 .image-grid-full-width {
  width:100%;
  display:flex;
- justify-content:space-around;
+ justify-content:space-evenly;
 }
 
 .image-grid-few {


### PR DESCRIPTION
Hi Craig!
The paddings around album items in grid view always looked a little bit off to me being uneven on left and right edges, and in-between, so I've tried to apply a small fix and want to introduce it to you. Please take a look if it makes sense. And thanks for your work btw.

Narrow view - before:
<img width="1785" alt="narrow-before" src="https://github.com/CDrummond/lms-material/assets/22818230/2a90b5c4-d94a-42c8-9e69-e83e63fd4776">

Narrow view - after:
<img width="1785" alt="narrow-after" src="https://github.com/CDrummond/lms-material/assets/22818230/4531c26d-9991-4396-8a1f-fb342d1cc55d">

Standard view - before:
<img width="1785" alt="standard-before" src="https://github.com/CDrummond/lms-material/assets/22818230/91e1a229-165f-4d22-a8ce-746f2bcb593e">

Standard view - after:
<img width="1785" alt="standard-after" src="https://github.com/CDrummond/lms-material/assets/22818230/6bef5867-3fb3-481a-b127-9c0203a86bca">