### PR TITLE
Pre-cache HiDPI version of the cover arts if needed

### DIFF
--- a/MaterialSkin/Plugin.pm
+++ b/MaterialSkin/Plugin.pm
@@ -152,6 +152,9 @@ sub initPlugin {
         Slim::Web::Pages->addRawFunction($DOWNLOAD_PARSER_RE, \&_downloadHandler);
         # make sure scanner does pre-cache artwork in the size the skin is using in browse modesl
         Slim::Control::Request::executeRequest(undef, [ 'artworkspec', 'add', '300x300_f', 'Material Skin' ]);
+    	if ($serverprefs->get('precacheHiDPIArtwork')) {
+            Slim::Control::Request::executeRequest(undef, [ 'artworkspec', 'add', '600x600_f', 'Material Skin (HiDPI)' ]);
+        }
 
         $skinMgr = Slim::Web::HTTP::getSkinManager();
     }
@@ -372,12 +375,11 @@ sub _cliCommand {
 
     if ($cmd eq 'info') {
         my $osDetails = Slim::Utils::OSDetect::details();
-        my $serverPrefs = preferences('server');
         $request->addResult('info', '{"server":'
                                 .'[ {"label":"' . string('INFORMATION_VERSION') . '", "text":"' . $::VERSION . ' - ' . $::REVISION . ' @ ' . $::BUILDDATE . '"},'
                                 .  '{"label":"' . string('INFORMATION_HOSTNAME') . '", "text":"' . Slim::Utils::Network::hostName() . '"},'
                                 .  '{"label":"' . string('INFORMATION_SERVER_IP') . '", "text":"' . Slim::Utils::Network::serverAddr() . '"},'
-                                .  '{"label":"' . string('INFORMATION_OPERATINGSYSTEM') . '", "text":"' . $osDetails->{'osName'} . ' - ' . $serverPrefs->get('language') .
+                                .  '{"label":"' . string('INFORMATION_OPERATINGSYSTEM') . '", "text":"' . $osDetails->{'osName'} . ' - ' . $serverprefs->get('language') .
                                       ' - ' . Slim::Utils::Unicode::currentLocale() . '"},'
                                 .  '{"label":"' . string('INFORMATION_ARCHITECTURE') . '", "text":"' . ($osDetails->{'osArch'} ? $osDetails->{'osArch'} : '?') . '"},'
                                 .  '{"label":"' . string('PERL_VERSION') . '", "text":"' . $Config{'version'} . ' - ' . $Config{'archname'} . '"},'


### PR DESCRIPTION
The pref is set by LMS when it sees a HiDPI capable display. You'd currently "only" pre-cache 300px, but not 600px, slowing down the scrolling on slower servers.