### PR TITLE
Fix version check.

### DIFF
--- a/MaterialSkin/Plugin.pm
+++ b/MaterialSkin/Plugin.pm
@@ -1260,8 +1260,7 @@ sub _cliCommand {
     }
 
     if ($cmd eq 'release-types') {
-        my @ver = split(/\./, $::VERSION);
-        if (int($ver[0])>=8 && int($ver[0])>=4) {
+        if (Slim::Utils::Versions->compareVersions($::VERSION, '8.4') >= 0) {
             my $relTypes = Slim::Schema::Album->releaseTypes();
             my $cnt = 0;
             foreach my $rt (@{$relTypes}) {


### PR DESCRIPTION
The current check is broken, as it's comparing against he first part of the version string even for the second digit.

Use LMS built-in `compareVersions()` instead.