### PR TITLE
Fix Danish translation

### DIFF
--- a/MaterialSkin/HTML/material/html/lang/da.json
+++ b/MaterialSkin/HTML/material/html/lang/da.json
@@ -87,7 +87,7 @@
 "Biography":"Biografi",
 "Bitrate":"Bithastighed",
 "Black":"Sort",
-"Browse":"Gennemse musikbibliotek",
+"Browse":"Musik",
 "Browse modes":"Måder at gennemgå musikbiblioteket på",
 "Browse music library":"Gå på opdagelse i dit musikbibliotek",
 "CD Player":"CD-afspiller",


### PR DESCRIPTION
Previous translation for "Browse" was too long to fit in mobile layout.