### PR TITLE
Get the external source info link from the `extid` value

### DIFF
--- a/MaterialSkin/HTML/material/html/js/track-sources.js
+++ b/MaterialSkin/HTML/material/html/js/track-sources.js
@@ -30,7 +30,7 @@ function getTrackSource(track) {
             if (track.url.startsWith(key)) {
                 if (undefined!=value.url) {
                     if (undefined!=value.url.from) {
-                        let srvUrl = track.url.replace(value.url.from, value.url.to);
+                        let srvUrl = (value.url.useextid ? track.extid : track.url).replace(value.url.from, value.url.to);
                         if (value.url.removeext) {
                             let parts = srvUrl.split('.');
                             parts.pop();

--- a/MaterialSkin/HTML/material/html/misc/track-sources.json
+++ b/MaterialSkin/HTML/material/html/misc/track-sources.json
@@ -86,6 +86,11 @@
     },
     "radioparadise:":{
         "name":"Radio Paradise",
+        "url":{
+            "useextid": true,
+            "from":"radioparadise:",
+            "to":"https://radioparadise.com/music/song/"
+        },
         "context":true,
         "extid":"radioparadise"
     }


### PR DESCRIPTION
... rather than the stream URL. This should allow Material to show a link for Radio Paradise (if using the latest plugin and LMS versions...).

I don't know whether this is the way to go. But in the case of RP the stream URL would never change, but the track's metadata would. Up for discussion.

Please note that for this to work you'll need the very latest LMS 8.4 plus RP v3.2.1+.