### PR TITLE
Reduce rather than clip icons in Favorites list

### DIFF
--- a/MaterialSkin/HTML/material/html/css/style.css
+++ b/MaterialSkin/HTML/material/html/css/style.css
@@ -542,8 +542,7 @@ div.v-subheader {
 }
 
 .image-grid-item-img {
- object-fit:cover;
- object-position:50% 0%;
+ object-fit:contain;
  display:block;
  margin-bottom:4px;
  padding-top:2px;
@@ -626,8 +625,7 @@ div.v-subheader {
 }
 
 .v-avatar img {
- object-fit:cover;
- object-position:50% 0%;
+ object-fit:contain;
 }
 
 .radio-image img {


### PR DESCRIPTION
I have radio stations in my list of favorites, but their icons are clipped, which makes them hard to recognize and doesn't look good. In the list of radio stations, on the other hand, they are reduced to fit, which looks much better. I propose this fix to the CSS rules for the favorites list: In two places change 'object-fit: cover' to 'object-fit: contain'; and remove the 'object-position', so the icon is centered rather than aligned at the top.