### PR TITLE
Use artist name only when single artist link from works

### DIFF
--- a/MaterialSkin/HTML/material/html/js/browse-page.js
+++ b/MaterialSkin/HTML/material/html/js/browse-page.js
@@ -1144,7 +1144,7 @@ var lmsBrowse = Vue.component("lms-browse", {
                     }
                 }
                 this.fetchItems(this.replaceCommandTerms({command:["albums"], params:[id, ARTIST_ALBUM_TAGS, SORT_KEY+ARTIST_ALBUM_SORT_PLACEHOLDER]}),
-                                {cancache:false, id:"artist_id:"+item.artist_id, title:item.subtitle, stdItem:STD_ITEM_ARTIST});
+                                {cancache:false, id:"artist_id:"+item.artist_id, title: item.work_id ? item.artists[0] : item.subtitle, stdItem:STD_ITEM_ARTIST});
             } else {
                 this.click(item, index, event);
             }


### PR DESCRIPTION
This makes the artist link behaviour when there is a single work artist consistent with the behaviour when there are multiple work artists and one is chosen from the pop-up.

It ensures that only the the artist name is passed in `title`, rather than artist--album, to the releases page, to match the search parameters.