### PR TITLE
Rename the plugin/extensions manager one more time...

### DIFF
--- a/MaterialSkin/Plugin.pm
+++ b/MaterialSkin/Plugin.pm
@@ -39,7 +39,7 @@ my $log = Slim::Utils::Log->addLogCategory({
 
 *getCurrentPlugins = Slim::Utils::Versions->compareVersions($::VERSION, '9.0.0') < 0
     ? \&Slim::Plugin::Extensions::Plugin::getCurrentPlugins
-    : \&Slim::Utils::PluginRepoManager::getCurrentPlugins;
+    : \&Slim::Utils::ExtensionsManager::getCurrentPlugins;
 
 my $prefs = preferences('plugin.material-skin');
 my $serverprefs = preferences('server');


### PR DESCRIPTION
I'm sorry for this, @CDrummond. After looking into the whole plugin management some more I realized that this module doesn't only manage the plugins, but applets and other "extensions", too. I therefore decided to rename it once again.

There's no rush to get this out: like before I've added some backwards compatibility code, leaving a warning in the logs. But otherwise the old code should continue to work. And it'll take a few more hours before the corresponding LMS change is out anyway.

Thanks!