### PR TITLE
performance fixes

### DIFF
--- a/MaterialSkin/HTML/material/html/js/browse-functions.js
+++ b/MaterialSkin/HTML/material/html/js/browse-functions.js
@@ -188,6 +188,8 @@ function browseActions(view, item, args, count, showCompositions, showWorks) {
             var params = [SORT_KEY+TRACK_SORT_PLACEHOLDER, PLAYLIST_TRACK_TAGS, 'work_id:'+args['work_id'], args['composer_id']];
             if (undefined!=args['performance']) {
                 params.push(args['performance']);
+            } else {
+		params.push('performance:-1');
             }
             if (item && item.album_id) {
                 params.push('album_id:'+item.album_id);

--- a/MaterialSkin/HTML/material/html/js/standarditems.js
+++ b/MaterialSkin/HTML/material/html/js/standarditems.js
@@ -191,6 +191,8 @@ function buildStdItemCommand(item, parentCommand) {
             }
             if (undefined!=item.performance) {
                 command.params.push("performance:"+item.performance);
+            } else {
+                command.params.push("performance:");
             }
         } else if (item.id.startsWith("genre_id:")) {
             for (var i=0, len=parentCommand.params.length; i<len; ++i) {


### PR DESCRIPTION
This makes sure the performance parameter is passed to the tracks command even if it is null, because null is meaningful (you may have an album where one version of the work has performance populated and a second one doesn't).

It also sets performance to -1 to indicate all performances (null or not) when browsing "all tracks".

It requires the latest https://github.com/LMS-Community/slimserver/pull/1109 to work properly. (This is now ready to go and also includes the fix to return work_id in the status command response.)

PLEASE make sure I've got this right and haven't broken anything else.

BTW, in testing I found that adding all tracks to the playlist using the buttons in the header is adding all tracks in the library when used from a Works--All Tracks list. This happens without these changes, but I wouldn't have a clue where to start looking for the bug: JSON request is:
JSON REQ: ["00:04:20:12:4b:74",["playlistcontrol","cmd:add","currentaction:3"]]