### PR TITLE
Adding new option to hide some players

### DIFF
--- a/MaterialSkin/HTML/EN/plugins/MaterialSkin/settings/basic.html
+++ b/MaterialSkin/HTML/EN/plugins/MaterialSkin/settings/basic.html
@@ -28,6 +28,10 @@
     <input type="checkbox" name="pref_combineAppsAndRadio" id="pref_combineAppsAndRadio" [% IF prefs.pref_combineAppsAndRadio %] checked [% END %] value="1"/>
     [% END %]
 
+    [% WRAPPER setting title="PLUGIN_MATERIAL_HIDE_PLAYERS" desc="PLUGIN_MATERIAL_HIDE_PLAYERS_DESC" %]
+    <input type="checkbox" name="pref_hidePlayers" id="pref_hidePlayers" [% IF prefs.pref_hidePlayers %] checked [% END %] value="1"/>
+    [% END %]
+
     [% WRAPPER setting title="PLUGIN_MATERIAL_SKIN_RELEASE_TYPE_ORDER" desc="PLUGIN_MATERIAL_SKIN_RELEASE_TYPE_ORDER_DESC" %]
     <textarea class="stdedit" name="pref_releaseTypeOrder" id="releaseTypeOrder" cols="45" rows="5">[% prefs.releaseTypeOrder %]</textarea>
     [% END %]

--- a/MaterialSkin/HTML/material/html/js/constants.js
+++ b/MaterialSkin/HTML/material/html/js/constants.js
@@ -168,7 +168,7 @@ const IFRAME_HOME_NAVIGATES_BROWSE_HOME = 1
 const IFRAME_HOME_CLOSES_DIALOGS = 2
 
 const SKIN_GENRE_TAGS = ['composer', 'conductor', 'band'];
-const SKIN_BOOL_OPTS = ['maiComposer', 'showComposer', 'showConductor', 'showBand', 'showAllArtists', 'artistFirst', IS_IOS ? 'xx' : 'allowDownload', 'showComment', 'noArtistFilter', 'genreImages', 'touchLinks', 'yearInSub', 'playShuffle', 'combineAppsAndRadio'];
+const SKIN_BOOL_OPTS = ['maiComposer', 'showComposer', 'showConductor', 'showBand', 'showAllArtists', 'artistFirst', IS_IOS ? 'xx' : 'allowDownload', 'showComment', 'noArtistFilter', 'genreImages', 'touchLinks', 'yearInSub', 'playShuffle', 'combineAppsAndRadio', 'hidePlayers'];
 const SKIN_INT_OPTS = ['respectFixedVol', 'commentAsDiscTitle', 'pagedBatchSize'];
 
 const MSK_REV_SORT_OPT = "msk-revsort:1";

--- a/MaterialSkin/HTML/material/html/js/lmsoptions.js
+++ b/MaterialSkin/HTML/material/html/js/lmsoptions.js
@@ -36,5 +36,6 @@ var lmsOptions = {techInfo: getLocalStorageBool('techInfo', false),
                   playShuffle: getLocalStorageBool('playShuffle', false),
                   time12hr: LMS_DEF_12HR,
                   listWorks: getLocalStorageBool('listWorks', false),
-                  combineAppsAndRadio: getLocalStorageBool('combineAppsAndRadio', false)
+                  combineAppsAndRadio: getLocalStorageBool('combineAppsAndRadio', false),
+                  hidePlayers: getLocalStorageBool("hidePlayers",false)
                 };

--- a/MaterialSkin/HTML/material/html/js/store.js
+++ b/MaterialSkin/HTML/material/html/js/store.js
@@ -317,6 +317,12 @@ const store = new Vuex.Store({
             }
         },
         setPlayers(state, players) {
+            if(lmsOptions.hidePlayers) {
+                var i=players.length;
+                while(i--) {
+                    if(players[i].name.substring(0,1)==("!")) players.splice(i,1);
+                }
+            }
             var changed = !state.players || state.players.length!=players.length;
             if (!changed) {
                 for (var i=0, len=state.players.length; i<len; ++i) {

--- a/MaterialSkin/Plugin.pm
+++ b/MaterialSkin/Plugin.pm
@@ -82,7 +82,7 @@ my @ADV_SEARCH_OTHER = ('content_type', 'contributor_namesearch.active1', 'contr
 
 my %IGNORE_PROTOCOLS = map { $_ => 1 } ('mms', 'file', 'tmp', 'http', 'https', 'spdr', 'icy', 'teststream', 'db', 'playlist');
 
-my @BOOL_OPTS = ('allowDownload', 'playShuffle', 'touchLinks', 'showAllArtists', 'artistFirst', 'yearInSub', 'showComment', 'genreImages', 'maiComposer', 'showComposer', 'showConductor', 'showBand', 'combineAppsAndRadio');
+my @BOOL_OPTS = ('allowDownload', 'playShuffle', 'touchLinks', 'showAllArtists', 'artistFirst', 'yearInSub', 'showComment', 'genreImages', 'maiComposer', 'showComposer', 'showConductor', 'showBand', 'combineAppsAndRadio', 'hidePlayers');
 
 sub initPlugin {
     my $class = shift;
@@ -137,6 +137,7 @@ sub initPlugin {
         yearInSub => 1,
         playShuffle => 0,
         combineAppsAndRadio => 0,
+        hidePlayers => 0,
         hideApps => '',
         hideExtras => ''
     });
@@ -464,6 +465,7 @@ sub _cliCommand {
         $request->addResult('yearInSub', $prefs->get('yearInSub'));
         $request->addResult('playShuffle', $prefs->get('playShuffle'));
         $request->addResult('combineAppsAndRadio', $prefs->get('combineAppsAndRadio'));
+        $request->addResult('hidePlayers', $prefs->get('hidePlayers'));
         $request->setStatusDone();
         return;
     }

--- a/MaterialSkin/Settings.pm
+++ b/MaterialSkin/Settings.pm
@@ -24,7 +24,7 @@ sub page {
 }
 
 sub prefs {
-    return ($prefs, qw(composergenres conductorgenres bandgenres maiComposer showComposer showConductor showBand password respectFixedVol showAllArtists artistFirst allowDownload commentAsDiscTitle showComment pagedBatchSize noArtistFilter releaseTypeOrder genreImages touchLinks yearInSub playShuffle combineAppsAndRadio));
+    return ($prefs, qw(composergenres conductorgenres bandgenres maiComposer showComposer showConductor showBand password respectFixedVol showAllArtists artistFirst allowDownload commentAsDiscTitle showComment pagedBatchSize noArtistFilter releaseTypeOrder genreImages touchLinks yearInSub playShuffle combineAppsAndRadio hidePlayers));
 }
 
 sub handler {

--- a/MaterialSkin/strings.txt
+++ b/MaterialSkin/strings.txt
@@ -580,3 +580,15 @@ PLUGIN_MATERIAL_COMBINE_APPS_AND_RADIO_DESC
 	FR	Fusionner les menus "Applications" et "Radio" en un seul menu "Applications" dans lequel est ajoutée une application "TuneIn" regroupant les éléments associés au plugin "Radio" (si ce plugin est activé).
 	NL	Combineer de 'Applicaties' en 'Radio' in een enkel 'Applicaties' menu, waarbij de 'TuneIn' applicatie, indien ingeschakeld, wordt gebruikt als vervanging voor de 'Radio' applicatie.
 	ZH_CN	将“程序”和“电台”菜单合并成单个“程序”菜单。“电台”作为“TuneIn”程序添加到合并后的菜单里（如果已启用）。
+
+PLUGIN_MATERIAL_HIDE_PLAYERS
+	EN	Hide players
+	FR	Masquer les platines
+	NL	Hide players
+	ZH_CN	Hide players
+
+PLUGIN_MATERIAL_HIDE_PLAYERS_DESC
+	EN	Hide players with name starting with '!' character.
+	FR	Masquer les platines dont le nom commence par le caractère '!'.
+	NL	Hide players with name starting with '!' character.
+	ZH_CN	Hide players with name starting with '!' character.


### PR DESCRIPTION
This is a proposal to add an option enabling users to hide players from the list. It would be based on players to hide having name starting with '!'; this will let users who want to use that option to rename players to hide, prefixing them with '!', and enable this option.

My use case is that I use an old Squeezebox Touch, but only to control other players; it is still showing in the list of players while it is not connected to any audio output, thus I would like to be able to hide it. I tested that code locally and it seems to work fine, though I will admit I am unsure if the way I implemented this is the most elegant one.