### PR TITLE
`$mobile` is defined twice. Remove unused definition.

### DIFF
--- a/MaterialSkin/HTML/material/index.html
+++ b/MaterialSkin/HTML/material/index.html
@@ -4,7 +4,7 @@
  * Copyright (c) 2018-2024 Craig Drummond <craig.p.drummond@gmail.com>
  * MIT license.
 -->
- 
+
 <!DOCTYPE html>
 <html>
  <head>
@@ -137,7 +137,6 @@
   my $hideForKiosk=Plugins::MaterialSkin::Plugin->hideForKiosk();
   my $skinLanguages=Plugins::MaterialSkin::Plugin->skinLanguages();
   my $maxPlaylistEditSize=$lmsVersion>=80400 ? 1000 : 250;
-  my $mobile=0;
 
   # Query some LMS settingsnow to save JavaScript needing to make calls at start-up.
   my $rndMix=Slim::Utils::PluginManager->isEnabled('Slim::Plugin::RandomPlay::Plugin') ? 1 : 0;


### PR DESCRIPTION
With that line in there I'm getting errors logged:

```
[24-09-18 08:35:44.4284] Slim::Utils::Misc::msg (1320) Warning: [08:35:44.4277] "my" variable $mobile masks earlier declaration in same scope at (eval 1200) line 46.
```