### PR TITLE
Tweaks for Work/Grouping in play queue

### DIFF
--- a/MaterialSkin/HTML/material/html/js/queue-page.js
+++ b/MaterialSkin/HTML/material/html/js/queue-page.js
@@ -40,6 +40,8 @@ function buildArtistAlbumLines(i, queueAlbumStyle, queueContext) {
     let artistAlbum = undefined;
     let artistAlbumContext = undefined;
     let artistIsRemoteTitle = false;
+    let workGroupStr = i.work && i.composer ? i.composer+SEPARATOR+i.work : '';
+    workGroupStr += i.work && i.grouping ? SEPARATOR + i.grouping : i.grouping ? i.grouping : '';
     let artistStr = i.albumartist ? i.albumartist : i.artist ? i.artist : i.trackartist;
     if (queueAlbumStyle) {
         let id = i.albumartist ? i.albumartist_id : i.artist_id ? i.artist_id : i.trackartist_id;
@@ -69,8 +71,10 @@ function buildArtistAlbumLines(i, queueAlbumStyle, queueContext) {
         artistAlbumContext = undefined;
     }
     if (!queueAlbumStyle || !artistIsRemoteTitle) {
-        artistAlbum = addPart(artistAlbum, buildWorkLine(i, artistStr, 'queue'));
         artistAlbum = addPart(artistAlbum, buildAlbumLine(i, 'queue'));
+        if (workGroupStr) {
+            artistAlbum = '<obj>' + workGroupStr + '</obj>'+ SEPARATOR + artistAlbum;
+        }
         if (queueContext) {
             let al = i18n('<obj>from</obj> %1', buildAlbumLine(i, "queue")).replaceAll("<obj>", "<obj class=\"ext-details\">");
             artistAlbumContext = undefined == artistAlbumContext ? al : (artistAlbumContext + " " + al);


### PR DESCRIPTION
I wanted to push the Artist/Album text in the heading onto a second line, but couldn't work out how. 

Examples:

![image](https://github.com/user-attachments/assets/d103cd2f-8ada-45f8-8039-fe2e99e07f3d)

![image](https://github.com/user-attachments/assets/828aca74-682b-4bcf-841b-a8d1950a3f39)

![image](https://github.com/user-attachments/assets/100ae32c-44a1-4324-a2c8-5b43b99029c3)
