### PR TITLE
Handle multiple genres in play queue

### DIFF
--- a/MaterialSkin/HTML/material/html/js/queue-page.js
+++ b/MaterialSkin/HTML/material/html/js/queue-page.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-const PQ_STATUS_TAGS = "tags:cdegilqtuy" + (LMS_VERSION>=90000 ? "bhz1" : "") + "AAIKNSxx";
+const PQ_STATUS_TAGS = "tags:cdegilqtuy" + (LMS_VERSION>=90000 ? "bhz1" : "") + "AAIKNSxxGP";
 const PQ_REQUIRE_AT_LEAST_1_ITEM = new Set([PQ_SAVE_ACTION, PQ_MOVE_QUEUE_ACTION, PQ_SCROLL_ACTION, PQ_SORT_ACTION, REMOVE_DUPES_ACTION]);
 const PQ_REQUIRE_MULTIPLE_ITEMS = new Set([PQ_SCROLL_ACTION, SEARCH_LIST_ACTION, PQ_SORT_ACTION, REMOVE_DUPES_ACTION]);
 
@@ -52,9 +52,9 @@ function buildArtistAlbumLines(i, queueAlbumStyle, queueContext) {
             artistAlbum = buildLink(i.albumartist ? 'show_albumartist' : 'show_artist', id, artistStr, 'queue');
         }
     } else {
-        let useComposerTag = i.composer && lmsOptions.showComposer && useComposer(i.genre);
-        let useConductorTag = i.conductor && lmsOptions.showConductor && useConductor(i.genre);
-        let useBandTag = i.band && lmsOptions.showBand && useBand(i.genre);
+        let useComposerTag = i.composer && lmsOptions.showComposer && useComposer(i.genres);
+        let useConductorTag = i.conductor && lmsOptions.showConductor && useConductor(i.genres);
+        let useBandTag = i.band && lmsOptions.showBand && useBand(i.genres);
         artistAlbum = buildArtistLine(i, 'queue', undefined, undefined, useBandTag, useComposerTag, useConductorTag);
         artistAlbumContext = queueContext ? replaceBr(buildArtistWithContext(i, 'queue', useBandTag, useComposerTag, useConductorTag), " ") : undefined;
     }

--- a/MaterialSkin/HTML/material/html/js/utils.js
+++ b/MaterialSkin/HTML/material/html/js/utils.js
@@ -1041,7 +1041,8 @@ function getClickPos(ev) {
 }
 
 function useArtistTagType(genre, genres) {
-    return (genre && genres.has(genre)) || (1==genres.size && genres.has('*'));
+    const genreArray = genre.toString().split(/\s*,\s*/);
+    return (genreArray.some(g => genres.has(g))) || (1==genres.size && genres.has('*'));
 }
 
 function useComposer(genre) {


### PR DESCRIPTION
I'm still playing with https://github.com/CDrummond/lms-material/pull/993 but along the way I found something to fix: if a track is tagged with multiple genres, the value returned in `genre` will be randomly one of them. So get and use `genres` instead.