### PR TITLE
subheading, work,grouping,performance WIP

### DIFF
--- a/MaterialSkin/HTML/material/html/js/browse-resp.js
+++ b/MaterialSkin/HTML/material/html/js/browse-resp.js
@@ -1412,7 +1412,25 @@ function parseBrowseResp(data, parent, options, cacheKey, parentCommand, parentG
                         subtitleContext=i18n('<obj>from</obj> %1', buildAlbumLine(i, "browse", false)).replaceAll("<obj>", "<obj class=\"ext-details\">");
                     }
                 }
-                if (undefined!=i.disc && !isSearchResult && !isAllTracks && !isCompositions) {
+                if ( (undefined!=i.work && undefined!=i.composer || undefined!=i.grouping) && !isSearchResult && !isAllTracks && !isCompositions) {
+                    let discNum = undefined;
+                    if (i.composer && i.work) {
+                        discNum = i.composer+SEPARATOR+i.work;
+                        if (i.performance) {discNum += SEPARATOR+i.performance};
+                        if (i.grouping) {discNum += SEPARATOR+i.grouping};
+                    } else {
+                    	discNum = i.grouping;
+                    }
+                    if (discs.has(discNum)) {
+                        var entry = discs.get(discNum);
+                        entry.total++;
+                        entry.duration+=duration;
+                    } else {
+                        let title = discNum;
+                        discs.set(discNum, {pos: resp.items.length, total:1, duration:duration, title:title});
+                    }
+                }
+                else if (undefined!=i.disc && !isSearchResult && !isAllTracks && !isCompositions) {
                     let discNum = parseInt(i.disc);
                     if (discs.has(discNum)) {
                         var entry = discs.get(discNum);

--- a/MaterialSkin/HTML/material/html/js/itemlinks.js
+++ b/MaterialSkin/HTML/material/html/js/itemlinks.js
@@ -238,16 +238,22 @@ function buildAlbumLine(i, page, plain) {
     }
 }
 
-/*
-function buildWorkLine(i, artist, page, plain) {
+
+function buildWorkLine(i, page, plain) {
     var line = undefined;
-    if (i.work && artist) {
-        var work = i.work;
-        if (i.work_id && (!IS_MOBILE || lmsOptions.touchLinks) && !plain) {
-            work="<obj class=\"link-item\" onclick=\"showWork(event, "+i.work_id+",\'"+escape(work)+"\',\'"+escape(artist)+"\', \'"+page+"\')\">" + work + "</obj>";
-        }
+    if ((!IS_MOBILE || lmsOptions.touchLinks) && !plain && i.work && i.composer) {
+        var work="<obj class=\"link-item\" onclick=\"showWork(event, "+i.work_id+",\'"+escape(i.work)+"\',\'"+escape(i.composer)+"\', \'"+page+"\')\">" + i.composer + SEPARATOR + i.work + "</obj>";
         line=addPart(line, work);
     }
     return line;
 }
-*/
+
+function buildGroupingLine(i, page, plain) {
+    var line = undefined;
+    if ((!IS_MOBILE || lmsOptions.touchLinks) && !plain && i.grouping) {
+        var grouping = "<obj>" + i.grouping + "</obj>";
+        line=addPart(line, grouping);
+    }
+    return line;
+}
+


### PR DESCRIPTION
Transferred from #993 

I hope I've got it right, my local git was in a bit of a mess, as usual.

I've attached a test album which has 3 works on 2 discs, the first work runs over onto the second disc. You can test the grouping stuff with any old album tagged with Grouping set to eg "Side A" or "Side B".

Three issues I know about:

1. As mentioned before, needs template/css mods when the albumStyle header goes onto 2 lines.
2. Play Queue operatons from the work or grouping do not work (see JS console output below).
3.  The popup when adding the whole album to the play queue from the album list still has the option "All Discs" rather than "All Works" or "All Groups".

And the coding style is quite bad!
[Alicia.zip](https://github.com/user-attachments/files/18099978/Alicia.zip)


```
vue.min.js?r=2.7.15:11 TypeError: Cannot read properties of undefined (reading 'id')
    at browseDoListAction (browse-functions.js?r=5.6.0:2650:17)
    at browseDoList (browse-functions.js?r=5.6.0:2639:9)
    at a.doList (browse-page.js?r=5.6.0:1601:13)
    at browseItemAction (browse-functions.js?r=5.6.0:1591:18)
    at a.itemAction (browse-page.js?r=5.6.0:1059:17)
    at click (eval at cc (vue.min.js?r=2.7.15:1:1), <anonymous>:3:32217)
    at pn (vue.min.js?r=2.7.15:11:22017)
    at HTMLImageElement.r (vue.min.js?r=2.7.15:11:10396)
    at i._wrapper (vue.min.js?r=2.7.15:11:59549)
```
