### PR TITLE
Adjust album cover size on NP screen for tablets

### DIFF
--- a/MaterialSkin/HTML/material/html/css/desktop.css
+++ b/MaterialSkin/HTML/material/html/css/desktop.css
@@ -7,7 +7,7 @@
 
 :root {
  --bottom-toolbar-height:var(--desktop-npbar-height);
- --np-portrait-image-size:min(calc(var(--100vh) - (var(--main-toolbar-height) + var(--bottom-pad) + 260px) - (var(--np-image-border)*2)), 100vw - (var(--np-image-border)*2), var(--50vh));
+ --np-portrait-image-size:min(calc(var(--100vh) - (var(--main-toolbar-height) + var(--bottom-pad) + 260px) - (var(--np-image-border)*2)), 100vw - (var(--np-image-border)*2));
  --np-image-landscape-height:min(50vw, calc(var(--100vh) - (var(--main-toolbar-height) + var(--np-controls-height) + 66px + var(--bottom-pad))));
  --np-image-landscape-size:min(var(--np-image-landscape-height) - (var(--np-image-border)*2), 50vw - (var(--np-image-border)*2));
  --np-image-landscape-wide-height:min(calc(var(--100vh) - (var(--main-toolbar-height) + var(--bottom-pad) + var(--desktop-np-wide-pad))), var(--np-wide-left) - var(--bottom-pad));


### PR DESCRIPTION
Hi Craig, I've tried to adjust album cover sizes in portrait view for desktop - looks like they can use a little bit more space. This seems to do the trick, not sure about the purpose of 50vh check though. Tried different tablet devices simulated in browser devtools - looks correct. E.g. iPad:

before:

![ipad_before](https://github.com/user-attachments/assets/b9944f3c-f68f-43f1-9517-0a025384e154)

after:

![ipad_after](https://github.com/user-attachments/assets/79f21c8a-e240-470e-8f54-fec1825ee826)