### PR TITLE
Fix URL parsing

### DIFF
--- a/MaterialSkin/HTML/material/html/js/browse-resp.js
+++ b/MaterialSkin/HTML/material/html/js/browse-resp.js
@@ -452,7 +452,7 @@ function parseBrowseResp(data, parent, options, cacheKey, parentCommand, parentG
                 }
 
                 if (i.parseURLs) {
-                    i.title = i.title.replace(/\b(https?:\/\/[A-Za-z0-9\-_\.\!~*'();\/?:@&=+$,]+)/, "<a href=\"$1\" target=\"_blank\">$1</a>");
+                    i.title = i.title.replace(/\b(https?:\/\/[A-Za-z0-9\-_\.\!~*'();\/?:@%&=+$,]+)/, "<a href=\"$1\" target=\"_blank\">$1</a>");
                 }
 
                 if (isAppsTop && i.actions && i.actions.go && i.actions.go.params && i.actions.go.params.menu) {


### PR DESCRIPTION
Don't know whether you've copied that regex from my implementation in LMS. But it seems to be missing the `%` sign, too. This change should fix https://forums.slimdevices.com/forum/user-forums/3rd-party-software/1740806-advanced-tag-view-urls-not-always-shown-correctly#post1740984