### PR TITLE
Fix descending sort toggle

### DIFF
--- a/MaterialSkin/HTML/material/html/js/browse-page.js
+++ b/MaterialSkin/HTML/material/html/js/browse-page.js
@@ -1263,7 +1263,7 @@ var lmsBrowse = Vue.component("lms-browse", {
                     this.command.params.push(MSK_REV_SORT_OPT);
                 }
                 if (isAlbums) {
-                    setAlbumSort(this.command, this.inGenre, sort.key, reverseSort);
+                    setAlbumSort(this.command, this.inGenre, sort, reverseSort);
                 } else {
                     let stdItem = this.current.stdItem ? this.current.stdItem : this.current.altStdItem;
                     setTrackSort(getTrackSort(stdItem).by, reverseSort, stdItem);


### PR DESCRIPTION
I noticed a problem testing my sort enhancements thing, and I think it's an existing problem: when changing the toggle for descending, local storage was not being written properly, it ended up undefined. I _think_ this fixes it.