### PR TITLE
Tweaks for grouping and subtitles

### DIFF
--- a/MaterialSkin/HTML/material/html/js/browse-resp.js
+++ b/MaterialSkin/HTML/material/html/js/browse-resp.js
@@ -1358,16 +1358,18 @@ function parseBrowseResp(data, parent, options, cacheKey, parentCommand, parentG
             let compilationAlbumArtist = undefined;
             let extraSubs = [];
             let browseContext = getLocalStorageBool('browseContext', false);
-            let splitIntoGroupings = lmsOptions.useGrouping && (undefined==parent || undefined==parent.multi || MULTI_GROUP_ALBUM==parent.multi);
+            let splitIntoGroupings = lmsOptions.useGrouping && (undefined==parent || undefined==parent.multi || MULTI_GROUP_ALBUM==parent.multi || isWork);
 
             for (let idx=0, loop=data.result.titles_loop, loopLen=loop.length; idx<loopLen; ++idx) {
                 let i = makeHtmlSafe(loop[idx]);
+                let baseTitle = i.title;
                 let title = trackTitle(i);
                 let duration = parseFloat(i.duration || 0);
                 let tracknum = undefined==i.tracknum ? 0 : parseInt(i.tracknum);
                 let highlight = false;
                 if (tracknum>0 && showTrackNumbers) {
                     title = (tracknum>9 ? tracknum : ("0" + tracknum))+SEPARATOR+title;
+                    baseTitle = (tracknum>9 ? tracknum : ("0" + tracknum))+SEPARATOR+baseTitle;
                     //title = tracknum + ". " + title; // SlimBrowse format
                     if (isSearchResult && undefined!=i.disc) {
                         title = i.disc+"."+title;
@@ -1577,6 +1579,7 @@ function parseBrowseResp(data, parent, options, cacheKey, parentCommand, parentG
                 resp.items.push({
                               id: "track_id:"+i.id,
                               title: title,
+                              baseTitle: baseTitle,
                               subtitle: subtitle,
                               subtitleContext: subtitleContext,
                               //icon: "music_note",
@@ -1753,12 +1756,13 @@ function parseBrowseResp(data, parent, options, cacheKey, parentCommand, parentG
             let removeDiscNumbers = false;
             let removeGroupFilter = false;
             if (allTracksGrouping==0) {
-                if (groupings.size>1 && splitIntoGroups) {
+                if ( (groupings.size>1 || isWork) && splitIntoGroups ) {
                     let d = 0;
                     for (var idx=0, len=resp.items.length; idx<len; ++idx) {
                         resp.items[idx].filter = resp.items[idx].gfilter;
                         resp.items[idx].gfilter = undefined;
                         resp.items[idx].disc = undefined;
+                        resp.items[idx].title = resp.items[idx].baseTitle;
                     }
                     for (let k of groupings.keys()) {
                         let grouping = groupings.get(k);

--- a/MaterialSkin/HTML/material/html/js/nowplaying-functions.js
+++ b/MaterialSkin/HTML/material/html/js/nowplaying-functions.js
@@ -96,7 +96,7 @@ function nowplayingOnPlayerStatus(view, playerStatus) {
         view.playerStatus.current.id = playerStatus.current.id;
     }
     if (playerStatus.current.title!=view.playerStatus.current.title) {
-        view.playerStatus.current.title = playerStatus.current.title;
+        view.playerStatus.current.title = trackTitle(playerStatus.current);
         trackChanged = true;
     }
     if (playerStatus.current.tracknum!=view.playerStatus.current.tracknum) {
@@ -623,6 +623,7 @@ function nowplayingFetchTrackInfo(view) {
     let html="";
     let trk = view.playerStatus.current;
 
+    trk.title = trackTitle(trk);
     if (undefined!=trk.artist) {
         let entry = nowplayingArtistEntry(trk, 'artist', 'ARTIST');
         if (entry.length>1) {

--- a/MaterialSkin/HTML/material/html/js/nowplaying-page.js
+++ b/MaterialSkin/HTML/material/html/js/nowplaying-page.js
@@ -1485,9 +1485,9 @@ var lmsNowPlaying = Vue.component("lms-now-playing", {
         },
         title() {
             if (this.$store.state.nowPlayingTrackNum && this.playerStatus.current.tracknum) {
-                return formatTrackNum(this.playerStatus.current)+SEPARATOR+this.playerStatus.current.title;
+                return formatTrackNum(this.playerStatus.current)+SEPARATOR+trackTitle(this.playerStatus.current);
             }
-            return this.playerStatus.current.title;
+            return trackTitle(this.playerStatus.current);
         },
         desktopLayout() {
             return this.$store.state.desktopLayout

--- a/MaterialSkin/HTML/material/html/js/server.js
+++ b/MaterialSkin/HTML/material/html/js/server.js
@@ -597,9 +597,6 @@ var lmsServer = Vue.component('lms-server', {
                               };
             if (data.playlist_loop && data.playlist_loop.length>0) {
                 player.current = makeHtmlSafe(data.playlist_loop[0]);
-                if (undefined!=player.current.title) {
-                    player.current.title = trackTitle(player.current);
-                }
                 splitMultiples(player.current, true);
                 player.current.isClassical = undefined!=player.current.isClassical && 1==parseInt(player.current.isClassical);
                 player.current.time = undefined==data.time ? undefined : "stop"==data.mode ? 0 : parseFloat(data.time);


### PR DESCRIPTION
Track listings and play queue (album style): don't add Work to Track Title if it's under a Work subheading.

Works track listings: show a work subheading, rather than repeat Work in every track entry.

Play Queue: use new LMS status command tag /2/ which returns `contiguous_groups`, so that queue sections for non-contiguous albums in "album style" mode are not such a mess. (The LMS change has already been merged.)

Now Playing/MAI: ensure full track title (ie Work + Title) is always used.

