### PR TITLE
Simplify player volume control determination

### DIFF
--- a/MaterialSkin/HTML/material/html/js/server.js
+++ b/MaterialSkin/HTML/material/html/js/server.js
@@ -560,7 +560,7 @@ var lmsServer = Vue.component('lms-server', {
                 logCometdMessage("PLAYER ("+playerId+")", data);
             }
             var isCurrent = this.$store.state.player && playerId==this.$store.state.player.id;
-            var dvc = 1==parseInt(data.digital_volume_control) || (undefined!=data.has_digital_out && 0==parseInt(data.has_digital_out));
+            var dvc = 1==parseInt(data.digital_volume_control) || (undefined!=data.use_volume_control && 1==parseInt(data.use_volume_control));
             var player = { ison: undefined==data.power || 1==parseInt(data.power),
                            isplaying: data.mode === "play",
                            iswaiting: data.mode === "play" && data.waitingToPlay,


### PR DESCRIPTION
Replace the 'has_digital_out' status query attribute with 'use_volume_control', a more straightforward approach that places the responsibility for determining a player's volume behavior completely in LMS, allowing for future changes while preserving backward LMS compatibility.