### PR TITLE
Don't show Grouping text if it's the same as Work

### DIFF
--- a/MaterialSkin/HTML/material/html/js/browse-resp.js
+++ b/MaterialSkin/HTML/material/html/js/browse-resp.js
@@ -1502,7 +1502,7 @@ function parseBrowseResp(data, parent, options, cacheKey, parentCommand, parentG
                                 if (i.performance) {
                                     groupingTitle += SEPARATOR+i.performance;
                                 }
-                                if (i.grouping) {
+                                if (i.grouping && i.grouping!=i.work) {
                                     groupingTitle += SEPARATOR+i.grouping;
                                 }
                             } else {

--- a/MaterialSkin/HTML/material/html/js/queue-page.js
+++ b/MaterialSkin/HTML/material/html/js/queue-page.js
@@ -75,7 +75,7 @@ function buildArtistAlbumLines(i, queueAlbumStyle, queueContext) {
         artistAlbum = addPart(artistAlbum, buildAlbumLine(i, 'queue'));
         let work = buildWorkLine(i, 'queue');
         if (work && queueAlbumStyle) {
-            artistAlbum = addPart(work, i.grouping)+'<br/><div class="pq-gsub">'+artistAlbum+'</div>';
+            artistAlbum = addPart(work, i.work!=i.grouping ? i.grouping : undefined)+'<br/><div class="pq-gsub">'+artistAlbum+'</div>';
             ws = true;
         } else if (queueAlbumStyle && i.grouping) {
             artistAlbum +='<br/><div class="pq-gsub">'+i.grouping+'</div>';

--- a/MaterialSkin/HTML/material/html/js/utils-deferred.js
+++ b/MaterialSkin/HTML/material/html/js/utils-deferred.js
@@ -471,7 +471,6 @@ function sortPlaylist(view, playerId, title, command) {
 }
 
 function inRect(x, y, rx, ry, rw, rh, padding) {
-    rx-padding, rx+rw+padding, ry-padding, ry+rh+padding);
     return x>=(rx-padding) && x<=(rx+rw+padding) && y>=(ry-padding) && y<=(ry+rh+padding);
 }
 


### PR DESCRIPTION
Musicbrainz might create WORK and GROUPING tags containing the same data. When this happens, don't show Grouping.

Also fixes a small problem with https://github.com/CDrummond/lms-material/commit/8da7c00229745601666fff1b9c72ad6232bcac83 ;)