### PR TITLE
Fix album-style play queue when useGrouping=false

### DIFF
--- a/MaterialSkin/HTML/material/html/js/queue-page.js
+++ b/MaterialSkin/HTML/material/html/js/queue-page.js
@@ -74,11 +74,14 @@ function buildArtistAlbumLines(i, queueAlbumStyle, queueContext) {
     if (!queueAlbumStyle || !artistIsRemoteTitle) {
         artistAlbum = addPart(artistAlbum, buildAlbumLine(i, 'queue'));
         let work = buildWorkLine(i, 'queue');
-        if (work && queueAlbumStyle) {
+        if (lmsOptions.useGrouping && work && queueAlbumStyle) {
             artistAlbum = addPart(work, i.work!=i.grouping ? i.grouping : undefined)+'<br/><div class="pq-gsub">'+artistAlbum+'</div>';
             ws = true;
-        } else if (queueAlbumStyle && i.grouping) {
+        } else if (lmsOptions.useGrouping && queueAlbumStyle && i.grouping) {
             artistAlbum +='<br/><div class="pq-gsub">'+i.grouping+'</div>';
+            ws = true;
+        } else if (i.disccount && i.disccount>1 || i.discsubtitle) {
+            artistAlbum +='<br/><div class="pq-gsub">'+ (i.discsubtitle ? i.discsubtitle : i18n("Disc %1", i.disc)) +'</div>';
             ws = true;
         }
         if (queueContext) {


### PR DESCRIPTION
If useGrouping=false, it was splitting on disc number, but using the current track work/grouping as the title. Use album title in that case, and add second line with the disc subtitle/disc number.

I'm not sure how to implement something like this in queue-page:

https://github.com/CDrummond/lms-material/blob/6b62e8823be19ccab669746d6cc20406442f52ec/MaterialSkin/HTML/material/html/js/browse-resp.js#L1799-L1805