### PR TITLE
Pass work_id when adding by track ids, update LMS version check

### DIFF
--- a/MaterialSkin/HTML/material/html/js/browse-functions.js
+++ b/MaterialSkin/HTML/material/html/js/browse-functions.js
@@ -2629,7 +2629,7 @@ function browseBuildFullCommand(view, item, act) {
                         }
                         if (loop[i].startsWith("artist_id:") && !item.id.startsWith("album_id:")) {
                             command.params.push(SORT_KEY+ARTIST_ALBUM_SORT_PLACEHOLDER);
-                            if (item.stdItem==STD_ITEM_WORK_COMPOSER && LMS_VERSION>=90003) {
+                            if (item.stdItem==STD_ITEM_WORK_COMPOSER && LMS_VERSION>=90100) {
                                 command.params.push("work_id:-1");
                             }
                         }
@@ -2640,9 +2640,11 @@ function browseBuildFullCommand(view, item, act) {
                 }
             } else if (item.id.startsWith("genre_id:")) {
                 command.params.push(SORT_KEY+ALBUM_SORT_PLACEHOLDER);
-                if (item.stdItem==STD_ITEM_WORK_GENRE && LMS_VERSION>=90003) {
+                if (item.stdItem==STD_ITEM_WORK_GENRE && LMS_VERSION>=90100) {
                     command.params.push("work_id:-1");
                 }
+            } else if (item.id.startsWith("track_id:") && item.work_id && LMS_VERSION>=90100) {
+                command.params.push("work_id:-1");
             }
 
             let id = originalId(item.id);
@@ -2687,7 +2689,7 @@ function browseDoListAction(view, list, act, index) {
                 ids+=","+originalId(list[i].id).split(":")[1];
             }
         }
-        var command = browseBuildFullCommand(view, {id:ids}, /*PLAY_ACTION==act && undefined!=index ? ADD_ACTION :*/ act);
+        var command = browseBuildFullCommand(view, {id:ids, work_id:list[0].work_id}, /*PLAY_ACTION==act && undefined!=index ? ADD_ACTION :*/ act);
         if (command.command.length===0) {
             bus.$emit('showError', undefined, i18n("Don't know how to handle this!"));
             return;

--- a/MaterialSkin/HTML/material/html/js/browse-resp.js
+++ b/MaterialSkin/HTML/material/html/js/browse-resp.js
@@ -1620,7 +1620,8 @@ function parseBrowseResp(data, parent, options, cacheKey, parentCommand, parentG
                               duration: duration>0 ? duration : undefined,
                               durationStr: duration>0 ? formatSeconds(duration) : undefined,
                               highlight: highlight,
-                              idx: idx
+                              idx: idx,
+                              work_id: i.work_id
                           });
 
                 if (highlight) {


### PR DESCRIPTION
Pass through `work_id` when adding queue entries by track id list. LMS needs this to trigger writing the `#ADDEDFROMWORK` flag.

Change LMS version check to 9.1, because Michael wants this to be released in 9.1 first. If all goes well, we'll backport to LMS 9.0.