### PR TITLE
Add basic styling for the list/grid view toggle in the LMS 9.1 plugin manager

### DIFF
--- a/MaterialSkin/HTML/material/html/css/classic-skin/mods.css
+++ b/MaterialSkin/HTML/material/html/css/classic-skin/mods.css
@@ -805,6 +805,14 @@ table td input[type=checkbox] {
  margin-right:13px;
 }
 
+#viewToggle {
+  background-color: var(--border-color);
+  vertical-align:middle;
+  width:15px;
+  height:15px;
+  margin-left:12px;
+ }
+
 .lms-settings-section-SETUP_PLUGINS_9 div#innerSettingsBlock {
  height:calc((var(--vh, 1vh)*100) - (var(--all-pad) + 247px))!important;
 }


### PR DESCRIPTION
@CDrummond - I've committed a change in LMS 9.1 which allows users to toggle the plugin list between the grid and a list view (see https://github.com/LMS-Community/slimserver/issues/1294). I'm using a SVG image left of the category filter dropdown to toggle between the two modes. This works ok in Material. But the styling loses the color when toggling modes. Unfortunately I'm not familiar enough with Material to make it work. Could you please pick this change up from here? Thanks!