### PR TITLE
Tweak the icon corner radius for the plugin list view

### DIFF
--- a/MaterialSkin/HTML/material/html/css/classic-skin/mods.css
+++ b/MaterialSkin/HTML/material/html/css/classic-skin/mods.css
@@ -784,6 +784,10 @@ table td input[type=checkbox] {
  border-radius:8px;
 }
 
+#pluginListPanel.pluginListList .pluginItem div:first-of-type div:first-of-type > img:first-of-type {
+ border-radius:4px;
+}
+
 .pluginList ul.thumbWrap li.thumbWrap {
  border:solid 1px var(--border-color);
 }


### PR DESCRIPTION
Use 4px instead of 8px, as the icons are too small for the larger radius.

before: ![Screenshot 2025-04-30 at 08 19 32](https://github.com/user-attachments/assets/041e135e-bc1e-4948-8837-875ef270b52f) after: ![Screenshot 2025-04-30 at 08 19 17](https://github.com/user-attachments/assets/e39dd2f9-f757-46c9-be01-d8e8865f5c9d)

