### PR TITLE
fix playlist multi-delete

### DIFF
--- a/MaterialSkin/Plugin.pm
+++ b/MaterialSkin/Plugin.pm
@@ -1967,6 +1967,7 @@ sub _cliClientCommand {
             Slim::Player::Playlist::refreshPlaylist($client);
         }
         $request->setStatusDone();
+        Slim::Control::Request::notifyFromArray($client, ['playlist', 'delete', '_index']);
         return;
     }
 


### PR DESCRIPTION
I noticed that when restarting the server immediately after doing a multi-select/delete of tracks from the playlist, the removed tracks came back, because the client playlist on disc is not updated.

Probably not noticed so far as you'd need to restart the server before making any additional changes to the playlist.

@michaelherger is this the correct method for this?