### PR TITLE
Handle playlists imported from streaming services.

### DIFF
--- a/MaterialSkin/Plugin.pm
+++ b/MaterialSkin/Plugin.pm
@@ -1907,7 +1907,7 @@ sub _cliCommand {
                     next;
                 }
                 $request->addResultLoop("playlists_loop", $cnt, ${key}, ${val});
-                if ($key eq "url") {
+                if ($key eq "url" && _startsWith("${val}", "file:")) {
                     my $path = Slim::Utils::Misc::pathFromFileURL($val);
                     if (-e $path) {
                         my $mtime = (stat $path)[9];


### PR DESCRIPTION
Don't attempt to generate a path for URL's representing playlists imported from Qobuz, for example, which generate the following error message in the log when passed to "Slim::Utils::Misc::pathFromFileURL".

```
[25-10-21 19:59:16.8126] Slim::Utils::Misc::pathFromFileURL (233) Error: Path isn't a file URL: qobuz://2418316.qbz [25-10-21 19:59:16.8131] Slim::Utils::Misc::pathFromFileURL (233) Backtrace:

   frame 0: Slim::Utils::Log::logBacktrace (/usr/share/perl5/Slim/Utils/Misc.pm line 233)
   frame 1: Slim::Utils::Misc::pathFromFileURL (/var/lib/squeezeboxserver/cache/InstalledPlugins/Plugins/MaterialSkin/Plugin.pm line 1911)
   frame 2: Plugins::MaterialSkin::Plugin::_cliCommand (/usr/share/perl5/Slim/Control/Request.pm line 1879)
   frame 3: (eval) (/usr/share/perl5/Slim/Control/Request.pm line 1879)
   frame 4: Slim::Control::Request::execute (/usr/share/perl5/Slim/Web/JSONRPC.pm line 484)
   frame 5: Slim::Web::JSONRPC::requestMethod (/usr/share/perl5/Slim/Web/JSONRPC.pm line 283)
   frame 6: (eval) (/usr/share/perl5/Slim/Web/JSONRPC.pm line 283)
   frame 7: Slim::Web::JSONRPC::handleURI (/usr/share/perl5/Slim/Web/HTTP.pm line 489)
   frame 8: Slim::Web::HTTP::processHTTP (/usr/share/perl5/Slim/Networking/IO/Select.pm line 123)
   frame 9: (eval) (/usr/share/perl5/Slim/Networking/IO/Select.pm line 119)
   frame 10: Slim::Networking::IO::Select::__ANON__ (/usr/share/perl5/Slim/Networking/IO/Select.pm line 168)
   frame 11: (eval) (/usr/share/perl5/Slim/Networking/IO/Select.pm line 168)
   frame 12: Slim::Networking::IO::Select::loop (/usr/sbin/squeezeboxserver line 621)
   frame 13: main::idle (/usr/sbin/squeezeboxserver line 570)
   frame 14: main::main (/usr/sbin/squeezeboxserver line 1105)
```