### PR TITLE
Add missing German translations

### DIFF
--- a/MaterialSkin/HTML/material/html/lang/de.json
+++ b/MaterialSkin/HTML/material/html/lang/de.json
@@ -706,7 +706,7 @@
 "Fixed clock": "Fixierte Uhr",
 "Local Playlist": "Lokale Wiedergabeliste",
 "Most Played": "Meistgespielt",
-"Moving clock": "Bewegte Uhr",
+"Moving clock": "Wandernde Uhr",
 "New Music": "Neue Musik",
 "Newest": "Neueste",
 "No screensaver.": "Kein Bildschirmschoner.",


### PR DESCRIPTION
@CDrummond, I wasn't sure about `Remote Playlist` (therefore the draft status of this PR).

Does "remote" refer to playlists originating from Remote Libraries (which currently translates to `Netzwerk-Musiksammlungen`)?

Note: `Netzwerk-Musiksammlungen` refers to music libraries available over a network. While "Netzwerk" is not a literal translation of "remote", this is the term currently used in the German UI for Remote Libraries.