### PR TITLE
Clean up external Extras handler.

### DIFF
--- a/MaterialSkin/HomeExtraBase.pm
+++ b/MaterialSkin/HomeExtraBase.pm
@@ -1,0 +1,40 @@
+package Plugins::MaterialSkin::HomeExtraBase;
+
+use strict;
+
+use base qw(Slim::Plugin::OPMLBased);
+use Plugins::MaterialSkin::Plugin;
+
+sub initPlugin {
+	my ($class, %args) = @_;
+
+	my $extra = delete $args{extra};
+
+	$class->SUPER::initPlugin(%args);
+
+	Plugins::MaterialSkin::Plugin->registerHomeExtra($args{tag}, {
+		title => $extra->{title},
+		icon  => $extra->{icon},
+		needsPlayer => $extra->{needsPlayer},
+
+		handler => sub { $class->handleExtra(@_) },
+	});
+}
+
+#  we don't want these menus to be shown anywhere but as Home Extras
+sub initJive {[]}
+
+sub handleExtra {
+	my ($class, $client, $cb, $count) = @_;
+
+	Slim::Control::Request::executeRequest($client,
+		[ $class->tag, 'items', 0, $count || Plugins::MaterialSkin::Plugin::NUM_HOME_ITEMS(), 'menu:1' ],
+		sub {
+			my $response = shift;
+			my $results = $response->getResults() || {};
+			$cb->($results);
+		}
+	);
+}
+
+1;

--- a/MaterialSkin/PresetsExtra.pm
+++ b/MaterialSkin/PresetsExtra.pm
@@ -1,0 +1,44 @@
+package Plugins::MaterialSkin::PresetsExtra;
+
+use strict;
+
+use base qw(Plugins::MaterialSkin::HomeExtraBase);
+
+use Slim::Utils::Prefs;
+
+my $serverPrefs = preferences('server');
+
+sub initPlugin {
+    my $class = shift;
+
+    $class->SUPER::initPlugin(
+        feed => \&handleFeed,
+        tag  => 'PresetsExtra',
+        extra => {
+            title => 'Presets',
+            icon => '/material/html/images/preset_MTL_icon_looks_one.png',
+            needsPlayer => 1,
+        }
+    );
+}
+
+sub handleFeed {
+    my ($client, $cb, $args) = @_;
+
+    my $presets = [ map {
+        {
+            type => $_->{type},
+            name => $_->{text},
+            url  => $_->{URL},
+            play => $_->{URL},
+            favorites_url  => $_->{URL},
+            image => Slim::Player::ProtocolHandlers->iconForURL($_->{URL}, $client),
+        }
+    } grep {
+        $_->{type} eq 'audio' || $_->{type} eq 'playlist'
+    } @{ $serverPrefs->client($client || (Slim::Player::Client::clients())[0])->get('presets') || [] } ];
+
+    $cb->({ items => $presets });
+}
+
+1;


### PR DESCRIPTION
Improve/fix/rework Presets Extras. Don't know whether it makes any more sense to you know. But I put it up here, as the 1001 Albums plugin might still be little useful to you. With this version and latest 9.1 commit (! - there seems to be a bug somewhere in the async requests handling...) I at least get a full screen of extras - reliably.

<img width="565" height="1443" alt="Bildschirmfoto 2025-11-17 um 15 03 50" src="https://github.com/user-attachments/assets/f8b5b204-533c-4ecd-8ab0-f3830ff3a5a6" />

But having that many Extras relying on external data clearly adds a timing penalty to the first load... It would take a second or more before they all show up. But subsequent calls should be faster as data is being cached.

Interestingly there seems to be a problem with local artwork.