### PR TITLE
Allow plugins/3rd parties to trigger a home extra update

### DIFF
--- a/MaterialSkin/HTML/material/html/js/browse-page.js
+++ b/MaterialSkin/HTML/material/html/js/browse-page.js
@@ -2485,6 +2485,9 @@ var lmsBrowse = Vue.component("lms-browse", {
         bus.$on('browse-home', function() {
             this.goHome();
         }.bind(this));
+        bus.$on('refresh-home', function() {
+            this.getHomeExtra();
+        }.bind(this));
         bus.$on('browse-action', function(act, idx) {
             if (idx>=0 && idx<this.items.length) {
                 this.itemAction(act, this.items[idx], idx, undefined);

--- a/MaterialSkin/HTML/material/html/js/server.js
+++ b/MaterialSkin/HTML/material/html/js/server.js
@@ -823,6 +823,7 @@ var lmsServer = Vue.component('lms-server', {
             this.cancelHomeRefreshTimer();
             this.homeRefreshTimer = setTimeout(function () {
                 lmsCommand("", ["material-skin", "home-extra-3rdparty"]).then(({data}) => {
+                    bus.$emit('refresh-home');
                     if (data && data.result && data.result.items) {
                         this.$store.commit('setHome3rdPartyExtraLists', JSON.parse(data.result.items));
                     }

--- a/MaterialSkin/Plugin.pm
+++ b/MaterialSkin/Plugin.pm
@@ -567,6 +567,10 @@ sub getHomeExtra3rdPartyItems {
     } keys %$HOME_EXTRAS ]);
 }
 
+sub signalHomeExtraUpdate {
+    Slim::Control::Request::notifyFromArray(undef, ['material-skin', 'notification', 'internal', 'refresh-home']);
+}
+
 #sub _checkPlayQueue {
 #    my $request = shift;
 #    if (!$prefs->get('playShuffle')) {


### PR DESCRIPTION
Don't only update the extra configuration, but the actual items, too. Some plugins change their content, like the random play does. But we want them to be able to update without the user having to interact with the menu. Eg. 1001 Albums would update once a day. Currently the user has to either navigate away from home and back, or re-load the page in order to pick up the latest album. With this change the plugin will be able to push an event to the frontend.