### PR TITLE
Fix Group player update dialog

### DIFF
--- a/MaterialSkin/HTML/material/html/js/groupplayers-dialog.js
+++ b/MaterialSkin/HTML/material/html/js/groupplayers-dialog.js
@@ -172,7 +172,7 @@ Vue.component('lms-groupplayers-dialog', {
                        'powerMaster:'+(this.options.powerMaster ? 1 : 0),
                        'powerPlay:'+(this.options.powerPlay ? 1 : 0),
                        'greedy:'+(this.options.greedy ? 1 : 0),
-                       'weakVolume:'+(this.options.greedy ? 1 : 0)
+                       'weakVolume:'+(this.options.weakVolume ? 1 : 0)
                       ];
 
             if (this.prevName != name) {


### PR DESCRIPTION
When a Group player is updated via the "Edit group player" dialog, the "Do not set volume" option is mistakenly set to the value of the "Always synchronize all players" checkbox instead of its own. Yet another victim of "Copy/Paste".    ;-)