### PR TITLE
Fix missing album name in clipboard image.

### DIFF
--- a/MaterialSkin/HTML/material/html/js/npshare-dialog.js
+++ b/MaterialSkin/HTML/material/html/js/npshare-dialog.js
@@ -300,7 +300,7 @@ Vue.component('lms-npshare-dialog', {
                     trackartist:playerStatus.current.trackartist,
                     album:undefined==playerStatus.current.album
                             ? undefined 
-                            : (playerStatus.current.year && playerStatus.current.year>0
+                            : playerStatus.current.album+(playerStatus.current.year && playerStatus.current.year>0
                                 ? " ("+ playerStatus.current.year+")"
                                 : ""),
                     extid: playerStatus.current.extid


### PR DESCRIPTION
The album name is not being re-populated in the clipboard image after player status updates.