### PR TITLE
Show work header for single-work albums.

### DIFF
--- a/MaterialSkin/HTML/material/html/js/browse-resp.js
+++ b/MaterialSkin/HTML/material/html/js/browse-resp.js
@@ -1484,7 +1484,13 @@ function parseBrowseResp(data, parent, options, cacheKey) {
             let compilationAlbumArtist = undefined;
             let extraSubs = [];
             let browseContext = getLocalStorageBool('browseContext', false);
-            let splitIntoGroupings = undefined==parent || undefined==parent.multi || MULTI_GROUP_ALBUM==parent.multi;
+            // Attempt grouping whenever the album isn't already in multi-disc mode. The per-track
+            // logic produces no groupings for albums without work/grouping tags, and the gates
+            // further down (groupings.size>0) suppress header output in that case. Excluding
+            // MULTI_DISC_ALBUM preserves disc-based headers and the disc-choice prompt for
+            // multi-disc single-work albums (e.g. a 3-CD St Matthew Passion) where disc grouping
+            // is the more useful structure.
+            let splitIntoGroupings = undefined==parent || MULTI_DISC_ALBUM!=parent.multi;
 
             for (let idx=0, loop=data.result.titles_loop, loopLen=loop.length; idx<loopLen; ++idx) {
                 let i = makeHtmlSafe(loop[idx]);
@@ -1831,7 +1837,7 @@ function parseBrowseResp(data, parent, options, cacheKey) {
                                          ? parent.subtitle
                                          : undefined;
 
-            let willShowGroupHeaders = allTracksGrouping==0 && (groupings.size>1 || isWork) && splitIntoGroups;
+            let willShowGroupHeaders = allTracksGrouping==0 && groupings.size>0 && splitIntoGroups;
             if (resp.items.length>1) {
                 let showArtists = (new Set(artists)).size>1;
                 if (!showArtists && undefined!=albumArtist) {
@@ -1897,7 +1903,7 @@ function parseBrowseResp(data, parent, options, cacheKey) {
             let removeDiscNumbers = false;
             let removeGroupFilter = false;
             if (allTracksGrouping==0) {
-                if ( (groupings.size>1 || isWork) && splitIntoGroups ) {
+                if ( groupings.size>0 && splitIntoGroups ) {
                     let d = 0;
                     for (var idx=0, len=resp.items.length; idx<len; ++idx) {
                         resp.items[idx].filter = resp.items[idx].gfilter;


### PR DESCRIPTION
This addresses LMS-Community/slimserver#1572 by ensuring a work header appears for each work regardless of whether it is the only work in a release. This is both helpful because useful info like composer that would otherwise be missing is now shown and because showing the work header for any work is more consistent.

Before the change, this single-work album was missing the work header
<img width="1549" height="768" alt="image" src="https://github.com/user-attachments/assets/423ec971-4f05-4665-b9ec-2317a163409f" />

After the change, the work header is there, showing that Bach is the composer for the work
<img width="2002" height="561" alt="image" src="https://github.com/user-attachments/assets/294d9a94-ecc6-4f5e-9143-c9ad921fec08" />

which agrees with what it is in multi-work albums
<img width="1664" height="929" alt="image" src="https://github.com/user-attachments/assets/04c744dd-5180-425a-84de-7bf3e196f63b" />

Since adding a "single work album" flag seemed too much like an *ad hoc* hack when the real issue is whether it has works at all, the implementation (a joint effort of me and Claude Code) now says that if there is any groupings they get a group header while remaining careful to avoid inadvertently creating things like a disk header if there is only one disk. This does result in two behavior changes
* If there is an explicit grouping tag, the group is always displayed
* If there is an album that has some tracks that are works but some that are not, the work headers are now consistently displayed with the non-work tracks in an "Others" header

My sense is that those are likewise good refinements that enhance consistency, but others may well disagree, so calling out explicitly.
