### PR TITLE
Forgotten replacement, no impact, just optimized and clearer code

### DIFF
--- a/MaterialSkin/Plugin.pm
+++ b/MaterialSkin/Plugin.pm
@@ -2258,7 +2258,7 @@ sub _handleHomeExtraCmd {
                 my $id = $extra->{id};
 
                 my $args = { 
-                    index    => $request->getParam('_p2') || 0,
+                    index    => $index,
                     quantity => $extra->{count} && $extra->{count} > $count ? $extra->{count} : $count || NUM_HOME_ITEMS,
                 };
                 $args->{user_id} = $userId if $userId;

--- a/MaterialSkin/Plugin.pm
+++ b/MaterialSkin/Plugin.pm
@@ -2258,8 +2258,8 @@ sub _handleHomeExtraCmd {
                 my $id = $extra->{id};
 
                 my $args = { 
-                    index    => $request->getParam('_p2') || 0,
-                    quantity => $extra->{count} && $extra->{count} > $count ? $extra->{count} : $count || NUM_HOME_ITEMS,
+                    index    => $index,
+                    quantity => $extra->{count} && $extra->{count} > $count ? $extra->{count} : $count,
                 };
                 $args->{user_id} = $userId if $userId;
                 my $features = $request->getParam('features');


### PR DESCRIPTION
In lines 2113 and 2118, $index is already defined and contains the request parameter '_P2'. $index should therefore be used in the subsequent code as well; hence the change in line 2261.