### PR TITLE
Custom actions on streaming / app browse items

### DIFF
--- a/MaterialSkin/HTML/material/html/js/browse-resp.js
+++ b/MaterialSkin/HTML/material/html/js/browse-resp.js
@@ -651,6 +651,43 @@ function parseBrowseResp(data, parent, options, cacheKey) {
                     i.menu.push(SHOW_IMAGE_ACTION);
                 }
 
+                // Surface custom actions on app/online (streaming) browse items. These arrive
+                // via item_loop (library content uses the *_loop branches) and bypass the
+                // STD_ITEMS action-menu path (online stdItems are >= STD_ITEM_ONLINE_ARTIST, so
+                // item.stdItem<STD_ITEMS.length is false), so add the CUSTOM_ACTIONS marker to
+                // the item's own menu and populate the view-level itemCustomActions. Service
+                // album rows (e.g. Qobuz New Releases) carry no favorites_url/metadata - only a
+                // playable item_id + title/subtitle - so key off playability and expose
+                // title/subtitle via item.album/item.artist so $ALBUMNAME/$ARTISTNAME resolve;
+                // $SERVICE carries the browsing service ('command').
+                let isOnlineAlbum  = STD_ITEM_ONLINE_ALBUM==i.stdItem;
+                let isOnlineArtist = STD_ITEM_ONLINE_ARTIST==i.stdItem;
+                let isAppItem = !isOnlineAlbum && !isOnlineArtist && !isOnlineTrack &&
+                                addedPlayAction && undefined==i.stdItem && !isFavorites && !isAppsTop;
+                if (isOnlineAlbum || isOnlineArtist || isOnlineTrack || isAppItem) {
+                    let btype    = isOnlineArtist ? "artist" : isOnlineTrack ? "track" : "album";
+                    let ocFilter = i.presetParams ? i.presetParams.favorites_url : undefined;
+                    // A plugin/app can define a custom-action category for its OWN view, named
+                    // "<command>-<type>" (e.g. "listentolater-album"). If defined - even as an
+                    // empty list - it takes precedence over the generic "online-*" category, so
+                    // a plugin's own list can show different actions, or none (an empty category
+                    // suppresses the generic actions on that app's items).
+                    let appCat = (undefined!=command) ? command+"-"+btype : undefined;
+                    let oca = (undefined!=appCat && undefined!=customActions && (appCat in customActions))
+                              ? getCustomActions(appCat, false, ocFilter)
+                              : getCustomActions("online-"+btype, false, ocFilter);
+                    if (undefined!=oca && oca.length>0) {
+                        if (isAppItem) {
+                            if (undefined==i.album)  { i.album   = i.title; }
+                            if (undefined==i.artist) { i.artist  = i.subtitle; }
+                            i.service = command;
+                        }
+                        addedDivider = addDivider(i, addedDivider);
+                        i.menu.push(CUSTOM_ACTIONS);
+                        if (undefined==resp.itemCustomActions) { resp.itemCustomActions = oca; }
+                    }
+                }
+
                 // Only show 'More' action if:
                 //    'more' is in baseActions and item has item_id
                 //    - OR -

--- a/MaterialSkin/HTML/material/html/js/customactions.js
+++ b/MaterialSkin/HTML/material/html/js/customactions.js
@@ -77,7 +77,7 @@ function performCustomAction(action, player, item) {
     }
 }
 
-const ACTION_KEYS = ['ID', 'NAME', 'ARTISTID', 'ARTISTNAME', 'ALBUMID', 'ALBUMNAME', 'TRACKID', 'TRACKNAME', 'TRACKNUM', 'DISC', 'GENREID', 'GENRENAME', 'YEAR', 'PLAYLISTID', 'PLAYLISTNAME', 'COMPOSER', 'CONDUCTOR', 'BAND', 'LANG', 'FAVURL', 'TITLE', 'ITEMID',];
+const ACTION_KEYS = ['ID', 'NAME', 'ARTISTID', 'ARTISTNAME', 'ALBUMID', 'ALBUMNAME', 'TRACKID', 'TRACKNAME', 'TRACKNUM', 'DISC', 'GENREID', 'GENRENAME', 'YEAR', 'PLAYLISTID', 'PLAYLISTNAME', 'COMPOSER', 'CONDUCTOR', 'BAND', 'LANG', 'FAVURL', 'TITLE', 'ITEMID', 'SERVICE', 'SUBTITLE',];
 
 function doReplacements(string, player, item) {
     let val = ''+string;
@@ -161,6 +161,14 @@ function doReplacements(string, player, item) {
         }
         if (undefined!=item.presetParams && undefined!=item.presetParams.favorites_url) {
             val=val.replaceAll("$FAVURL", item.presetParams.favorites_url);
+        }
+        // Online/app browse items: the service the item was browsed from, and the raw
+        // second line (e.g. "Artist (Year)") - see browse-resp.js item_loop handling.
+        if (undefined!=item.service) {
+            val=val.replaceAll("$SERVICE", item.service);
+        }
+        if (undefined!=item.subtitle) {
+            val=val.replaceAll("$SUBTITLE", item.subtitle);
         }
     }
     val=val.replaceAll("$HOST", window.location.hostname);


### PR DESCRIPTION
# Custom actions on streaming / app browse items

## What & why
Custom actions currently only appear on **library** items. There is no way to add one to a **streaming/app** album or track while browsing a service (Qobuz/Tidal/Deezer/Bandcamp — new releases, an artist's discography, search), because that content is delivered as SlimBrowse `item_loop` items which bypass Material's custom-action wiring.

Two reasons online/app items get nothing today:
1. They bypass the `STD_ITEMS` action-menu path — their `stdItem` is `>= STD_ITEM_ONLINE_ARTIST` (300/301), so the `item.stdItem < STD_ITEMS.length` gate in `browse-functions.js` is false and they never reach the `CUSTOM_ACTIONS` handling.
2. The `item_loop` branch never sets `resp.itemCustomActions`.

Both are needed to render a custom action: the `CUSTOM_ACTIONS` marker in the item's own `i.menu`, **and** the view-level `resp.itemCustomActions`.

## Change
**`browse-resp.js`** (in the `item_loop` per-item handling): for online items and playable app rows, add the `CUSTOM_ACTIONS` marker to the item's `i.menu` and populate `resp.itemCustomActions`.

- Service **album rows** (e.g. Qobuz New Releases) carry no `favorites_url`/`metadata` — only a playable `item_id` and a two-line `title`/`subtitle` — so the rule keys off **playability** (`addedPlayAction && undefined==i.stdItem && !isFavorites && !isAppsTop`), and exposes `i.title`/`i.subtitle` as `i.album`/`i.artist` so `$ALBUMNAME`/`$ARTISTNAME` resolve.
- Category lookup tries `"<command>-<type>"` (the app's own view, e.g. `qobuz-album`) before the generic `"online-<type>"`. A category that is **defined at all** — even an empty array — wins, so an app/plugin can customise actions on its own view or suppress the generic ones (an empty category).

**`customactions.js`** (`doReplacements`): add `$SERVICE` (the browsing service, i.e. the `command`) and `$SUBTITLE` (the raw second line), and register them in `ACTION_KEYS`.

## Example `actions.json`
```json
{
  "online-album": [
    { "title": "Add to Listen to Later", "icon": "playlist_add",
      "lmscommand": ["listentolater","addctx","name:$ALBUMNAME","artist:$ARTISTNAME","svc:$SERVICE","image:$IMAGE"] }
  ],
  "listentolater-album": []
}
```
Browsing Qobuz → New Releases, an album's "…" now shows the action, passing the album name, the "Artist (Year)" subtitle, the service, and the cover. Inside the `listentolater` app's own list, the empty `listentolater-album` category overrides `online-album`, so the action isn't offered there.

## Notes
- Scoped to playable app/online rows; library items use the `*_loop` branches and are unaffected.
- With new `online-*` categories, zero behaviour change unless a user adds them to `actions.json`.
- Verified locally against `Release 6.4.3` on LMS 9.1 with the Qobuz plugin (album rows in browse lists, and a plugin's own app view).
