### PR TITLE
Add 'spoton' to ALLOW_ADD_ALL whitelist

### DIFF
--- a/MaterialSkin/HTML/material/html/js/browse-page.js
+++ b/MaterialSkin/HTML/material/html/js/browse-page.js
@@ -8,7 +8,7 @@
 
 var B_ALBUM_SORTS=[ ];
 var B_TRACK_SORTS=[ ];
-const ALLOW_ADD_ALL = new Set(['trackinfo', 'youtube', 'spotty', 'qobuz', 'tidal', 'wimp' /*is Tidal*/, 'deezer', 'tracks', 'musicip', 'musicsimilarity', 'blissmixer', 'bandcamp']); // Allow add-all/play-all from 'trackinfo', as Spotty's 'Top Titles' access via 'More' needs this
+const ALLOW_ADD_ALL = new Set(['trackinfo', 'youtube', 'spotty', 'spoton', 'qobuz', 'tidal', 'wimp' /*is Tidal*/, 'deezer', 'tracks', 'musicip', 'musicsimilarity', 'blissmixer', 'bandcamp']); // Allow add-all/play-all from 'trackinfo', as Spotty's 'Top Titles' access via 'More' needs this
 const ALLOW_FAKE_ALL_TRACKS_ITEM = new Set(['youtube', 'qobuz']); // Allow using 'fake' add all item
 const MIN_WIDTH_FOR_DETAILED_SUB = 350;
 const MIN_WIDTH_FOR_HBTNS = 500;


### PR DESCRIPTION
## Summary

- Add `'spoton'` to `ALLOW_ADD_ALL` in `browse-page.js` so that the Play All / Add All toolbar buttons appear for SpotOn (a Spotify plugin for LMS)

SpotOn registers with `tag => 'spoton'` and returns standard OPMLBased audio track lists with proper `play`/`add` base actions. The existing `spotty` entry covers the legacy Spotty plugin; this adds the same support for SpotOn.

## Verified

Tested locally — with this change, Play All and Add All buttons appear correctly on SpotOn's Liked Songs, album tracks, playlist items, and podcast episodes in Material Skin.

Closes #1236