### PR TITLE
Fix non-ASCII double-encoding in 3rd-party Home Extra titles

### DIFF
--- a/MaterialSkin/Plugin.pm
+++ b/MaterialSkin/Plugin.pm
@@ -554,7 +554,7 @@ sub getHomExtrasIDs {
 }
 
 sub getHomeExtra3rdPartyItems {
-    return to_json([ map {
+    return Encode::decode_utf8(to_json([ map {
         my $item = $HOME_EXTRAS->{$_};
         {
             id          => $_,
@@ -563,7 +563,7 @@ sub getHomeExtra3rdPartyItems {
             icon        => $item->{icon},
             needsPlayer => $item->{needsPlayer}
         }
-    } keys %$HOME_EXTRAS ]);
+    } keys %$HOME_EXTRAS ]));
 }
 
 sub setHomeExtraTitle {


### PR DESCRIPTION
## Summary

`getHomeExtra3rdPartyItems()` calls `to_json()` which returns UTF-8 encoded bytes. When this byte string is passed through `addResult()` into the JSON-RPC response, the outer serializer treats each byte as a Latin-1 character and re-encodes it — producing double-encoded mojibake for non-ASCII characters (e.g. "Für dich gemacht" → "FÃ¼r dich gemacht").

The fix wraps `to_json()` with `Encode::decode_utf8()` to convert the bytes back to a Perl character string before returning. This way:

- **JSON-RPC path** (`addResult`): the outer serializer sees a character string and encodes it correctly (single encoding)
- **Template embed path** (`LMS_3RDPARTY_HOME_EXTRA`): Perl's I/O layer handles the character-to-UTF-8 conversion on output — still correct

`Encode` is already imported at the top of Plugin.pm.

## Affected

All 3rd-party Home Extra registrations with non-ASCII titles or subtitles. Confirmed with both Spotty and SpotOn using German translations.

Fixes #1243

## Test plan

- [x] Verify German (or other non-ASCII) 3rd-party Home Extra titles render correctly in MS Settings → Home Screen
- [x] Verify the `LMS_3RDPARTY_HOME_EXTRA` constant in the rendered HTML contains correct UTF-8 characters
- [x] Verify the `home-extra-3rdparty` JSON-RPC response contains correctly encoded strings