### PR TITLE
protocol discovery

### DIFF
--- a/MaterialSkin/Plugin.pm
+++ b/MaterialSkin/Plugin.pm
@@ -1671,9 +1671,9 @@ sub _cliCommand {
 
     if ($cmd eq 'protocols') {
         my $allPlugs =  Slim::Utils::PluginManager->allPlugins();
-        my %handlers = Slim::Player::ProtocolHandlers->registeredHandlers();
+        my @handlers = Slim::Player::ProtocolHandlers->registeredHandlers();
         my $count = 0;
-        foreach my $prot (keys %handlers) {
+        foreach my $prot (@handlers) {
             if (not exists($IGNORE_PROTOCOLS{$prot})) {
                 my $handler = Slim::Player::ProtocolHandlers->handlerForProtocol($prot);
                 if ($handler) {


### PR DESCRIPTION
Hi,

follow up on our DMs on lyrion forums .

Changing Material Skin’s protocol discovery by treating `Slim::Player::ProtocolHandlers->registeredHandlers()` as a list rather than assigning its return value to a hash.

LMS returns a list of registered protocol names. Assigning that list to `%handlers` interprets alternating entries as keys and values, causing an arbitrary subset of protocols to be omitted. 
As a result, services such as the plugin I'm currently workin' on may be classified as “Internet/Other” instead of being associated with their plugin.

I used 
`curl -s http://127.0.0.1:9000/jsonrpc.js   -H 'Content-Type: application/json'   --data '{"id":2,"method":"slim.request","params":["",["material-skin","protocols"]]}'`

Results before the change where randomized/ Afterwards constant. eg

`{"result":{"protocols_loop":[{"plugin":"Radio Paradise","scheme":"radioparadise"},{"scheme":"ardaudiothek","plugin":"ARD Audiothek"},{"scheme":"bandcamp","plugin":"Band's Campout"},{"scheme":"spoton","plugin":"SpotOn"},{"plugin":"Twitch","scheme":"twitch"},{"scheme":"twitchhls","plugin":"Twitch"}]},"method":"slim.request","id":2,"params":["",["material-skin","protocols"]]}`

Cheers