### PR TITLE
Add support for transcoded technical data (LMS 9.2.0).

### DIFF
--- a/MaterialSkin/HTML/material/html/js/server.js
+++ b/MaterialSkin/HTML/material/html/js/server.js
@@ -613,6 +613,23 @@ var lmsServer = Vue.component('lms-server', {
                 player.current.canseek = parseInt(data.can_seek);
                 player.current.remote_title = checkRemoteTitle(player.current);
                 player.current.replay_gain = data.replay_gain;
+
+                // if 'data.is_transcoded' is defined and set to '1', set the "transcoded" indicator for the technical display
+                // player.current.transcoded = parseInt(data.is_transcoded);
+
+                if (undefined!=data.bitrate) {
+                    player.current.bitrate = data.bitrate;
+                }
+                if (undefined!=data.type) {
+                    player.current.type = data.type;
+                }
+                if (undefined!=data.samplerate) {
+                    player.current.samplerate = data.samplerate;
+                }
+                if (undefined!=data.samplesize) {
+                    player.current.samplesize = data.samplesize;
+                }
+
                 //player.current.emblem = getEmblem(player.current.extid, player.current.url);
 
                 // BBC iPlayer Extras streams can change duration. *But* only the duration in data seems to


### PR DESCRIPTION
The new `is_transcoded` attribute in the main body signals that transcoding and/or resampling has taken place for the source track in LMS.  The `type`, `bitrate`, `samplerate`, and `samplesize` attributes in the playlist_loop continue to be those of the source track. However, one or more of these values may be overridden by a corresponding attribute/value pair in the main body of the JSON response in some circumstances, including when transcoding and/or resampling has taken place.