### PR TITLE
Fix image url's rewrite when using https proxy

### DIFF
--- a/MaterialSkin/HTML/material/html/js/iframe-dialog.js
+++ b/MaterialSkin/HTML/material/html/js/iframe-dialog.js
@@ -40,7 +40,7 @@ function remapClassicSkinIcons(doc, col) {
                             let url = undefined;
                             let path = imgList[i].src;
                             let pluginPath = "";
-                            if (imgList[i].src.startsWith("http:")) {
+                            if (imgList[i].src.startsWith("http:") || imgList[i].src.startsWith("https:")) {
                                 url = new URL(path);
                                 path = url.pathname;
                                 pluginPath = "plugins/"+url.search.split("=")[1]+(path.startsWith("/html/images/") ? "/" : "/html/images/");


### PR DESCRIPTION
As reported within AF's virtual library creator plugin
https://github.com/AF-1/lms-virtuallibrarycreator/issues/15

Images were not correctly displayed due to the image path rewrite only looking for http, not https.
Changed startswith to look for either.

Tested on my own setup and seems not to have any detrimental effect but I'm not a JS developer.