### PR TITLE
Show command result text for now playing alt buttons

### DIFF
--- a/MaterialSkin/HTML/material/html/js/nowplaying-page.js
+++ b/MaterialSkin/HTML/material/html/js/nowplaying-page.js
@@ -1172,7 +1172,11 @@ var lmsNowPlaying = Vue.component("lms-now-playing", {
         },
         doCommand(command, msg) {
             lmsCommand(this.$store.state.player.id, command).then(({data}) => {
-                if (undefined!=msg) {
+                let result = data && data.result;
+                let text = result && result.item_loop && result.item_loop[0] && result.item_loop[0].text;
+                if (undefined!=text) {
+                    bus.$emit('showMessage', text);
+                } else if (undefined!=msg) {
                     bus.$emit('showMessage', msg);
                 }
             });


### PR DESCRIPTION
repeatClicked/shuffleClicked pass the button's static pre-click tooltip to doCommand as the post-command message, so the toast always showed what the button would do, never what it just did. Now prefers the command response's item_loop[0].text when present.

This matches behaviour on Squeezeplay